### PR TITLE
Corrects username typo in helpers file

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.100.0.1
 dependencies:
   - condition: postgresql.enabled
@@ -16,3 +16,6 @@ dependencies:
     version: 1.x.x
 sources:
   - https://github.com/pact-foundation/pact_broker
+annotations:
+  artifacthub.io/changes: |
+    - "[Fix]: Fixes typo in username field in helpers file."

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/templates/_helpers.tpl
+++ b/charts/pact-broker/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Return the database name
 Return the Database username
 */}}
 {{- define "broker.databaseUser" -}}
-{{- ternary .Values.postgresql.auth.username .Values.externalDatabase.config.auth.user .Values.postgresql.enabled | quote -}}
+{{- ternary .Values.postgresql.auth.username .Values.externalDatabase.config.auth.username .Values.postgresql.enabled | quote -}}
 {{- end -}}
 
 


### PR DESCRIPTION
Corrects the `username` name typo in the helpers file from `user` to `username`.

Fixes: https://github.com/ChrisJBurns/pact-broker-chart/issues/6