### PR TITLE
Adds BasicAuth checks for username and password sourcing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: 3.*
+          version: 3.10.1
 
       - name: Add dependencies
         run: |

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.100.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -120,6 +120,7 @@ spec:
             # Authentication and authorization
             - name: PACT_BROKER_BASIC_AUTH_ENABLED
               value: {{ .Values.broker.config.basicAuth.enabled | quote }}
+            {{- if .Values.broker.config.basicAuth.enabled }}
             - name: PACT_BROKER_BASIC_AUTH_USERNAME
               {{- if .Values.broker.config.basicAuth.writeUser.username }}
               value: {{ .Values.broker.config.basicAuth.writeUser.username }}
@@ -129,6 +130,8 @@ spec:
                   name: {{ .Values.broker.config.basicAuth.writeUser.existingSecret }}
                   key: {{ .Values.broker.config.basicAuth.writeUser.existingSecretUsernameKey }}
               {{- end }}
+            {{- end }}
+            {{- if .Values.broker.config.basicAuth.enabled }}
             - name: PACT_BROKER_BASIC_AUTH_PASSWORD
               {{- if .Values.broker.config.basicAuth.writeUser.password }}
               value: {{ .Values.broker.config.basicAuth.writeUser.password }}
@@ -138,6 +141,8 @@ spec:
                   name: {{ .Values.broker.config.basicAuth.writeUser.existingSecret }}
                   key: {{ .Values.broker.config.basicAuth.writeUser.existingSecretPasswordKey }}
               {{- end }}
+            {{- end }}
+            {{- if .Values.broker.config.basicAuth.enabled }}
             - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
               {{- if .Values.broker.config.basicAuth.readUser.username }}
               value: {{ .Values.broker.config.basicAuth.readUser.username }}
@@ -147,6 +152,8 @@ spec:
                   name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}
                   key: {{ .Values.broker.config.basicAuth.readUser.existingSecretUsernameKey }}
               {{- end }}
+            {{- end }}
+            {{- if .Values.broker.config.basicAuth.enabled }}
             - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
               {{- if .Values.broker.config.basicAuth.readUser.password }}
               value: {{ .Values.broker.config.basicAuth.readUser.password }}
@@ -156,6 +163,7 @@ spec:
                   name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}
                   key: {{ .Values.broker.config.basicAuth.readUser.existingSecretPasswordKey }}
               {{- end }}
+            {{- end }}
             - name: PACT_BROKER_ALLOW_PUBLIC_READ
               value: {{ .Values.broker.config.basicAuth.allowPublicRead | quote }}
             - name: PACT_BROKER_PUBLIC_HEARTBEAT

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -135,7 +135,7 @@ broker:
 
       # -- Set to true if you basic authentication to be enabled
       #
-      enabled: true
+      enabled: false
 
       # -- Set to true if you want public read access, but still require credentials for writing.
       #
@@ -152,10 +152,10 @@ broker:
       writeUser:
 
         # -- Usermame for write access to the Pact Broker
-        username: "admin"
+        username: ""
 
         # -- Password for write access to the Pact Broker
-        password: "admin"
+        password: ""
 
         # -- Name of an existing Kubernetes secret containing credentials to access the Pact Broker
         existingSecret: ""
@@ -170,10 +170,10 @@ broker:
       readUser:
 
         # -- Usermame for read access to the Pact Broker
-        username: "admin"
+        username: ""
 
         # -- Password for read access to the Pact Broker
-        password: "admin"
+        password: ""
 
         # -- Name of an existing Kubernetes secret containing credentials to access the Pact Broker
         existingSecret: ""


### PR DESCRIPTION
Currently, the charts have default values for the `username` and `password`, so this means that even when setting `basicAuth. enabled: false`, it still enables it on the environment variable level because of functionality described [here](https://docs.pact.io/pact_broker/configuration/settings#basic_auth_enabled). 

Due to this, we are removing the default values in the values.yaml, and we also add an additional check on the `username` and `password` fields in the deployment.yaml, because otherwise, if the fields are not present/empty, it will try to source them from secrets - which in this case won't exist.

Addresses: https://github.com/ChrisJBurns/pact-broker-chart/issues/11

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>