### PR TITLE
Corrects HelmRepo URLs for New Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pact Broker Helm Chart
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) ![Release Charts](https://github.com/pact-foundation/pact-helm-chart/workflows/Release%20Charts/badge.svg?branch=master)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) ![Release Charts](https://github.com/pact-foundation/pact-broker-chart/workflows/Release%20Charts/badge.svg?branch=master)
 
 This repository will house the Pact Broker Helm Chart. It is important to note that this is a community maintained Helm Chart that has been brought under the Pact Foundation GitHub for ease of reference. The current maintainers are:
 
@@ -16,7 +16,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-helm repo add pact-broker https://chrisjburns.github.io/pact-broker-chart
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
 helm install pact-broker pact-broker/pact-broker
 ```
 

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.100.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -7,7 +7,7 @@ The Pact Broker is an application for sharing for Pact contracts and verificatio
 ## TL;DR
 
 ```console
-helm repo add pact-broker https://chrisjburns.github.io/pact-broker-chart
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
 helm install pact-broker pact-broker/pact-broker
 ```
 

--- a/charts/pact-broker/_readme_templates.gotmpl
+++ b/charts/pact-broker/_readme_templates.gotmpl
@@ -8,7 +8,7 @@
 ## TL;DR
 
 ```console
-helm repo add pact-broker https://chrisjburns.github.io/pact-broker-chart
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
 helm install pact-broker pact-broker/pact-broker
 ```
 


### PR DESCRIPTION
Corrects the Helm URL's for the new location of the Pact Broker Helm Chart.

Fixes: https://github.com/pact-foundation/pact-broker-chart/issues/14

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>