### PR TITLE
Adds Else If Clause to avoid error if unset

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Chris Burns
+Copyright (c) 2022 Pact Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.100.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
             - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
               {{- if .Values.broker.config.basicAuth.readUser.username }}
               value: {{ .Values.broker.config.basicAuth.readUser.username }}
-              {{- else }}
+              {{- else if .Values.broker.config.basicAuth.readUser.existingSecret }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}
@@ -157,7 +157,7 @@ spec:
             - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
               {{- if .Values.broker.config.basicAuth.readUser.password }}
               value: {{ .Values.broker.config.basicAuth.readUser.password }}
-              {{- else }}
+              {{- else if .Values.broker.config.basicAuth.readUser.existingSecret }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}


### PR DESCRIPTION
"Currently, if basic auth is enabled, and allowPublicRead is true, a username and password for the read user are required. If unset, the chart constructs a secretKeyRef with an empty key and name, that then errors out in a somewhat confusing manner on the non-existent key."

This PR adds an `else if` conditional so that if the secret is not set, there are no errors on installation.

Fixes: https://github.com/pact-foundation/pact-broker-chart/issues/13
Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>