### PR TITLE
Add volumes and volumeMounts to the chart

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.3.0
-appVersion: 2.100.0.1
+version: 0.3.1
+appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled
     name: postgresql

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -43,12 +43,12 @@ helm install pact-broker pact-broker/pact-broker
 | broker.config.basicAuth.readUser.existingSecretPasswordKey | The key to which holds the value of the password within the existingSecret | string | `""` |
 | broker.config.basicAuth.readUser.existingSecretUsernameKey | The key to which holds the value of the username within the existingSecret | string | `""` |
 | broker.config.basicAuth.readUser.password | Password for read access to the Pact Broker | string | `""` |
-| broker.config.basicAuth.readUser.username | Usermame for read access to the Pact Broker | string | `""` |
+| broker.config.basicAuth.readUser.username | Username for read access to the Pact Broker | string | `""` |
 | broker.config.basicAuth.writeUser.existingSecret | Name of an existing Kubernetes secret containing credentials to access the Pact Broker | string | `""` |
 | broker.config.basicAuth.writeUser.existingSecretPasswordKey | The key to which holds the value of the password within the existingSecret | string | `""` |
 | broker.config.basicAuth.writeUser.existingSecretUsernameKey | The key to which holds the value of the username within the existingSecret | string | `""` |
 | broker.config.basicAuth.writeUser.password | Password for write access to the Pact Broker | string | `""` |
-| broker.config.basicAuth.writeUser.username | Usermame for write access to the Pact Broker | string | `""` |
+| broker.config.basicAuth.writeUser.username | Username for write access to the Pact Broker | string | `""` |
 | broker.config.checkForPotentialDuplicatePacticipantNames | When a pact is published, the consumer, provider and consumer version resources are automatically created. To prevent a pacticipant (consumer or provider) being created multiple times with slightly different name variants (eg. FooBar/foo-bar/foo bar/Foo Bar Service), a check is performed to determine if a new pacticipant name is likely to be a duplicate of any existing applications. If it is deemed similar enough to an existing name, a 409 will be returned. | bool | `true` |
 | broker.config.createDeployedVersionsForTags | When true and a tag is created, if there is an environment with the name of the newly created tag, a deployed version is also created for the pacticipant version. | bool | `true` |
 | broker.config.databaseClean.cronSchedule | Set to a cron schedule that will run when your Broker is under the least operational load. | string | `"15 2 * * *"` |
@@ -111,6 +111,8 @@ helm install pact-broker pact-broker/pact-broker
 | broker.resources.requests.cpu |  | string | `"100m"` |
 | broker.resources.requests.memory |  | string | `"512Mi"` |
 | broker.tolerations | Pact Broker [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | list | `[]` |
+| broker.volumes | [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) | list | `[]` |
+| broker.volumeMounts | [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) | list | `[]` |
 | externalDatabase.config | External Database Configuration | object | `{"adapter":"","auth":{"existingSecret":"","existingSecretPasswordKey":"user-password","password":"","username":""},"databaseName":"","host":"","port":""}` |
 | externalDatabase.config.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
 | externalDatabase.config.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -2,14 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }} 
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "chart.name" . }}
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.broker.replicaCount }}
-  selector: 
+  selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/name: {{ include "chart.name" . }}
@@ -85,7 +85,7 @@ spec:
               value: {{ include "broker.databasePort" . }}
             - name: PACT_BROKER_DATABASE_NAME
               value: {{ include "broker.databaseName" . }}
-            - name: PACT_BROKER_DATABASE_USERNAME     
+            - name: PACT_BROKER_DATABASE_USERNAME
               value: {{ include "broker.databaseUser" . }}
             - name: PACT_BROKER_DATABASE_PASSWORD
               valueFrom:
@@ -223,6 +223,8 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.broker.resources | nindent 12 }}
+          volumeMounts:
+          {{- toYaml .Values.broker.volumeMounts | nindent 12 }}
           {{- if .Values.nodeSelector }}
           nodeSelector:
           {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -247,3 +249,5 @@ spec:
               path: /diagnostic/status/heartbeat
               port: http
           {{- end }}
+      volumes:
+      {{- toYaml .Values.broker.volumes | nindent 8 }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -339,9 +339,9 @@ broker:
 
   # Volumes to mount
   volumes: []
-    # - hostPath:
-    #     path: <HOST_PATH>
-    #   name: <VOLUME_NAME>
+    # - name: cache-volume
+    #   emptyDir:
+    #    sizeLimit: 500Mi
 
   # Volume mounts
   volumeMounts: []

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: pactfoundation/pact-broker
 
   # -- Pact Broker image tag (immutable tags are recommended)
-  tag: 2.100.0.1
+  tag: 2.105.0.1
 
   # -- Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -150,7 +150,7 @@ broker:
       # Pact Broker Basic Authentication Credentials For Write user
       writeUser:
 
-        # -- Usermame for write access to the Pact Broker
+        # -- Username for write access to the Pact Broker
         username: ""
 
         # -- Password for write access to the Pact Broker
@@ -168,7 +168,7 @@ broker:
       # Pact Broker Basic Authentication Credentials For Read user
       readUser:
 
-        # -- Usermame for read access to the Pact Broker
+        # -- Username for read access to the Pact Broker
         username: ""
 
         # -- Password for read access to the Pact Broker
@@ -337,6 +337,18 @@ broker:
     # -- Success threshold for readinessProbe
     successThreshold: 1
 
+  # Volumes to mount
+  volumes: []
+    # - hostPath:
+    #     path: <HOST_PATH>
+    #   name: <VOLUME_NAME>
+
+  # Volume mounts
+  volumeMounts: []
+    # - mountPath: <CONTAINER_PATH>
+    #   name: <VOLUME_NAME>
+    #   readOnly: true
+
 #  Service configuration
 service:
 
@@ -390,7 +402,6 @@ ingress:
 
     # -- ingress.tls.secretName The name to which the TLS Secret will be called
     secretName: ""
-
 
 # PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)
 postgresql:


### PR DESCRIPTION
Hey there.  I was setting up Pact Broker and found a few features that this chart lacks.

- Update app version to `2.105.0.1`
- Fix a few spelling errors in the documentation and comments
- Add ability to specify `volumes` and `volumeMounts` to the Pact Broker pods.  
  - This is useful if you want to use something like a Secrets Store CSI Driver, which requires a mount in order for its `SecretProviderClass` to trigger creation of the `Secret` object by pulling secrets from a remote location.  https://secrets-store-csi-driver.sigs.k8s.io/