### PR TITLE
Add serviceAccount spec to deployment template

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{ if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}


### PR DESCRIPTION
I noticed that even though the chart was designed to create a `serviceAccount`, it didn't have a way to attach the `serviceAccount` to a `deployment`.