### PR TITLE
chore(docs): adds contribution docs and PR template

### DIFF
--- a/.github/pr_request_template.md
+++ b/.github/pr_request_template.md
@@ -1,0 +1,18 @@
+## Description of the change
+
+<!-- Describe the change being requested. -->
+
+## Existing or Associated Issue(s)
+
+<!-- List any related issues. -->
+
+## Additional Information
+
+ <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
+
+## Checklist
+- [ ] [Signed your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
+- [ ] Chart version bumped in [README badges](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3).
+- [ ] Variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To prevew the content, use `helm-docs --dry-run`.
+- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

--- a/.github/pr_request_template.md
+++ b/.github/pr_request_template.md
@@ -14,5 +14,5 @@
 - [ ] [Signed your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
 - [ ] Chart version bumped in [README badges](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3).
-- [ ] Variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To prevew the content, use `helm-docs --dry-run`.
+- [ ] Variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
 - [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before making a contribution to the [Pact Broker Helm Chart](https://github.com/pact-foundation/pact-broker-chart) you will need to ensure the following steps have been done:
 - [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-- Run `helm template` on the changes you're making to ensure they are correctly rendered into Kuberenetes manifests.
+- Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
 - List tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
-- Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To prevew the content, use `helm-docs --dry-run`.
+- Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
 - If you are making changes to the Chart - remember to bump the Chart version following [SemVer](https://semver.org/). You will need to change the [Chart Version](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/Chart.yaml#L5) and the [Chart Badge](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3) on the README.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# How to Contribute to Pact Broker Helm Chart
+
+Before making a contribution to the [Pact Broker Helm Chart](https://github.com/pact-foundation/pact-broker-chart) you will need to ensure the following steps have been done:
+- [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+- Run `helm template` on the changes you're making to ensure they are correctly rendered into Kuberenetes manifests.
+- List tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
+- Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To prevew the content, use `helm-docs --dry-run`.
+- If you are making changes to the Chart - remember to bump the Chart version following [SemVer](https://semver.org/). You will need to change the [Chart Version](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/Chart.yaml#L5) and the [Chart Badge](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3) on the README.


### PR DESCRIPTION
Currently there are no documentation guides on contributing to this project. This PR adds some contributing documents and inserts a PR template with a checklist to remind contributors what steps need to be done before a PR is merged.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>