### PR TITLE
chore(security): adds oci build for helm chart

### DIFF
--- a/.github/pr_request_template.md
+++ b/.github/pr_request_template.md
@@ -14,5 +14,5 @@
 - [ ] [Signed your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
 - [ ] Chart version bumped in [README badges](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3).
-- [ ] Variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
+- [ ] Variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run --all-files` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
 - [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,4 +32,26 @@ jobs:
         with:
           config: cr.yaml
         env:
-          CR_TOKEN: "${{ secrets.TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a #pin@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b #pin@v2.8.1
+
+      - name: Publish and Sign OCI Charts
+        run: |
+          for chart in `find .cr-release-packages -name '*.tgz' -print`; do
+            helm push ${chart} oci://ghcr.io/${GITHUB_REPOSITORY} |& tee helm-push-output.log
+            file_name=${chart##*/}
+            chart_name=${file_name%-*}
+            digest=$(awk -F "[, ]+" '/Digest/{print $NF}' < helm-push-output.log)
+            cosign sign "ghcr.io/${GITHUB_REPOSITORY}/${chart_name}@${digest}"
+          done
+        env:
+          COSIGN_EXPERIMENTAL: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: helm-docs
         args:
-          # Make the tool search for charts only under the ``charts` directory
+          # Make the tool search for charts only under the `charts` directory
           - --chart-search-root=charts
           # The `./` makes it relative to the chart-search-root set above
           - --template-files=./_templates.gotmpl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ Before making a contribution to the [Pact Broker Helm Chart](https://github.com/
 - [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 - Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
 - List tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
-- Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
+- Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run --all-files` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
 - If you are making changes to the Chart - remember to bump the Chart version following [SemVer](https://semver.org/). You will need to change the [Chart Version](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/Chart.yaml#L5) and the [Chart Badge](https://github.com/pact-foundation/pact-broker-chart/blob/master/charts/pact-broker/README.md?plain=1#L3) on the README.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,44 @@ This repository will house the Pact Broker Helm Chart. It is important to note t
 
 We are always looking for maintainers, please let us know if you'd be interested. :)
 
-## Usage
-
-[Helm](https://helm.sh) must be installed to use the charts.
-Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
-
-Once Helm is set up properly, add the repo as follows:
+## TL;DR
 
 ```console
+helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+
 helm install pact-broker pact-broker/pact-broker
 ```
 
-You can then run `helm search repo pact-broker` to see the charts.
+## Usage
+
+The Pact Broker Chart is available in the following formats:
+- [Chart Repository](https://helm.sh/docs/topics/chart_repository/)
+- [OCI Artifacts](https://helm.sh/docs/topics/registries/)
+
+### Installing from Chart Repository
+
+The following command can be used to add the chart repository:
+
+```console
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+```
+
+Once the chart has been added, install one of the available charts:
+
+```console
+helm install pact-broker pact-broker/pact-broker
+```
+
+### Installing from an OCI Registry
+
+Charts are also available in OCI format. The list of available charts can be found [here](https://github.com/pact-foundation/pact-broker-chart/).
+
+Install one of the available charts:
+
+```shell
+helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/charts/pact-broker --version=<version>
+```
 
 ## Contributing
 

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,14 +1,46 @@
 # pact-broker
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 
 ## TL;DR
 
 ```console
+helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+
 helm install pact-broker pact-broker/pact-broker
+```
+
+## Usage
+
+The Pact Broker Chart is available in the following formats:
+- [Chart Repository](https://helm.sh/docs/topics/chart_repository/)
+- [OCI Artifacts](https://helm.sh/docs/topics/registries/)
+
+### Installing from Chart Repository
+
+The following command can be used to add the chart repository:
+
+```console
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+```
+
+Once the chart has been added, install one of the available charts:
+
+```console
+helm install pact-broker pact-broker/pact-broker
+```
+
+### Installing from an OCI Registry
+
+Charts are also available in OCI format. The list of available charts can be found [here](https://github.com/pact-foundation/pact-broker-chart/).
+
+Install one of the available charts:
+
+```shell
+helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/charts/pact-broker --version=<version>
 ```
 
 ## Source Code

--- a/charts/pact-broker/README.md.gotmpl
+++ b/charts/pact-broker/README.md.gotmpl
@@ -8,8 +8,40 @@
 ## TL;DR
 
 ```console
+helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+
 helm install pact-broker pact-broker/pact-broker
+```
+
+## Usage
+
+The Pact Broker Chart is available in the following formats:
+- [Chart Repository](https://helm.sh/docs/topics/chart_repository/)
+- [OCI Artifacts](https://helm.sh/docs/topics/registries/)
+
+### Installing from Chart Repository
+
+The following command can be used to add the chart repository:
+
+```console
+helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
+```
+
+Once the chart has been added, install one of the available charts:
+
+```console
+helm install pact-broker pact-broker/pact-broker
+```
+
+### Installing from an OCI Registry
+
+Charts are also available in OCI format. The list of available charts can be found [here](https://github.com/pact-foundation/pact-broker-chart/).
+
+Install one of the available charts:
+
+```shell
+helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/charts/pact-broker --version=<version>
 ```
 
 {{ template "chart.homepageLine" . }}


### PR DESCRIPTION
Adds ability to publish the `pact-broker` as an OCI artifact.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>