### PR TITLE
fix: improve PACT_BROKER_DATABASE_PASSWORD env var configuration

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -103,6 +103,11 @@ spec:
               value: {{ .Values.postgresql.auth.password | quote }}
                 {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
               value: {{ .Values.externalDatabase.config.auth.password | quote }}
+                {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "broker.databaseSecretName" . }}
+                  key: {{ include "broker.databaseSecretKey" . }}
                 {{- end }}
               {{- end }}
             - name: PACT_BROKER_DATABASE_SSLMODE

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -256,7 +256,7 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- toYaml .Values.broker.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -230,18 +230,6 @@ spec:
             {{- toYaml .Values.broker.resources | nindent 12 }}
           volumeMounts:
           {{- toYaml .Values.broker.volumeMounts | nindent 12 }}
-          {{- if .Values.nodeSelector }}
-          nodeSelector:
-          {{ toYaml .Values.nodeSelector | indent 8 }}
-          {{- end }}
-          {{- if .Values.tolerations }}
-          tolerations:
-          {{ toYaml .Values.tolerations | indent 8 }}
-          {{- end }}
-          {{- if .Values.affinity }}
-          affinity:
-          {{ toYaml .Values.affinity | indent 8 }}
-          {{- end }}
           {{- if .Values.broker.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.broker.livenessProbe "enabled" | toYaml | nindent 12 }}
             httpGet:
@@ -254,5 +242,17 @@ spec:
               path: /diagnostic/status/heartbeat
               port: http
           {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       volumes:
       {{- toYaml .Values.broker.volumes | nindent 8 }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -254,7 +254,7 @@ spec:
       nodeSelector:
       {{- toYaml .Values.broker.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.broker.tolerations }}
       tolerations:
       {{- toYaml .Values.broker.tolerations | nindent 8 }}
       {{- end }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -93,22 +93,15 @@ spec:
             - name: PACT_BROKER_DATABASE_USERNAME
               value: {{ include "broker.databaseUser" . }}
             - name: PACT_BROKER_DATABASE_PASSWORD
-              {{- if or .Values.postgresql.auth.existingSecret .Values.externalDatabase.config.auth.existingSecret }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "broker.databaseSecretName" . }}
-                  key: {{ include "broker.databaseSecretKey" . }}
-              {{- else }}
-                {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
+              {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
               value: {{ .Values.postgresql.auth.password | quote }}
-                {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
+              {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
               value: {{ .Values.externalDatabase.config.auth.password | quote }}
-                {{- else }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "broker.databaseSecretName" . }}
                   key: {{ include "broker.databaseSecretKey" . }}
-                {{- end }}
               {{- end }}
             - name: PACT_BROKER_DATABASE_SSLMODE
               value: {{ .Values.broker.config.databaseSslmode | quote }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -260,7 +260,7 @@ spec:
       {{- end }}
       {{- if .Values.affinity }}
       affinity:
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- toYaml .Values.broker.affinity | nindent 8 }}
       {{- end }}
       volumes:
       {{- toYaml .Values.broker.volumes | nindent 8 }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -252,7 +252,7 @@ spec:
           {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- toYaml .Values.broker.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations:

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -258,7 +258,7 @@ spec:
       tolerations:
       {{- toYaml .Values.broker.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.broker.affinity }}
       affinity:
       {{- toYaml .Values.broker.affinity | nindent 8 }}
       {{- end }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -250,7 +250,7 @@ spec:
               path: /diagnostic/status/heartbeat
               port: http
           {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.broker.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.broker.nodeSelector | nindent 8 }}
       {{- end }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -93,10 +93,18 @@ spec:
             - name: PACT_BROKER_DATABASE_USERNAME
               value: {{ include "broker.databaseUser" . }}
             - name: PACT_BROKER_DATABASE_PASSWORD
+              {{- if or .Values.postgresql.auth.existingSecret .Values.externalDatabase.config.auth.existingSecret }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "broker.databaseSecretName" . }}
                   key: {{ include "broker.databaseSecretKey" . }}
+              {{- else }}
+                {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
+              value: {{ .Values.postgresql.auth.password }}
+                {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
+              value: {{ .Values.externalDatabase.config.auth.password }}
+                {{- end }}
+              {{- end }}
             - name: PACT_BROKER_DATABASE_SSLMODE
               value: {{ .Values.broker.config.databaseSslmode | quote }}
             - name: PACT_BROKER_SQL_LOG_LEVEL

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
                   key: {{ include "broker.databaseSecretKey" . }}
               {{- else }}
                 {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
-              value: {{ .Values.postgresql.auth.password }}
+              value: {{ .Values.postgresql.auth.password | quote }}
                 {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
               value: {{ .Values.externalDatabase.config.auth.password }}
                 {{- end }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
                 {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
               value: {{ .Values.postgresql.auth.password | quote }}
                 {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.password }}
-              value: {{ .Values.externalDatabase.config.auth.password }}
+              value: {{ .Values.externalDatabase.config.auth.password | quote }}
                 {{- end }}
               {{- end }}
             - name: PACT_BROKER_DATABASE_SSLMODE


### PR DESCRIPTION
This PR solve 2 problems:

1. The identation of nodeSelector/tolerations/affinity is incorrect, impossibiliting your usage.
2. Currently is not possible declare PACT_BROKER_DATABASE_PASSWORD env variable as a text, only trought Kubernetes Secret. Is some cases it's necessary, example at "secret mutation" with HashCorp Vault or AWS Secret Manager, this PR only add the feature to be possible this, something similary done with "PACT_BROKER_BASIC_AUTH_PASSWORD".