### PR TITLE
fix: make externalDatabase.config.auth.password work

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -150,7 +150,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | externalDatabase.config.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
 | externalDatabase.config.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |
 | externalDatabase.config.auth.existingSecretPasswordKey | The key to which the password will be stored under within existing secret. | string | `"user-password"` |
-| externalDatabase.config.auth.password | Password for the non-root username for the Pact Broker | string | `""` |
+| externalDatabase.config.auth.password | Password for the non-root username for the Pact Broker | string | `nil` |
 | externalDatabase.config.auth.username | Non-root username for the Pact Broker | string | `""` |
 | externalDatabase.config.databaseName | External database name | string | `""` |
 | externalDatabase.config.host | Database host | string | `""` |

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -146,6 +146,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | broker.tolerations | Pact Broker [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | list | `[]` |
 | broker.volumeMounts |  | list | `[]` |
 | broker.volumes |  | list | `[]` |
+| broker.extraContainers | Additional containers to add to the Pact Broker pods | list | `[]` |
 | externalDatabase.config.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
 | externalDatabase.config.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |
 | externalDatabase.config.auth.existingSecretPasswordKey | The key to which the password will be stored under within existing secret. | string | `"user-password"` |

--- a/charts/pact-broker/templates/_helpers.tpl
+++ b/charts/pact-broker/templates/_helpers.tpl
@@ -82,6 +82,12 @@ Return the Database username
 {{- ternary .Values.postgresql.auth.username .Values.externalDatabase.config.auth.username .Values.postgresql.enabled | quote -}}
 {{- end -}}
 
+{{/*
+Return the Database password
+*/}}
+{{- define "broker.databasePassword" -}}
+{{- ternary .Values.postgresql.auth.password .Values.externalDatabase.config.auth.password .Values.postgresql.enabled | quote -}}
+{{- end -}}
 
 {{/*
 Return the Database Secret Name

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -93,10 +93,14 @@ spec:
             - name: PACT_BROKER_DATABASE_USERNAME
               value: {{ include "broker.databaseUser" . }}
             - name: PACT_BROKER_DATABASE_PASSWORD
+              {{- if (include "broker.databasePassword" .) }}
+              value: {{ include "broker.databasePassword" . }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "broker.databaseSecretName" . }}
                   key: {{ include "broker.databaseSecretKey" . }}
+              {{- end }}
             - name: PACT_BROKER_DATABASE_SSLMODE
               value: {{ .Values.broker.config.databaseSslmode | quote }}
             - name: PACT_BROKER_SQL_LOG_LEVEL

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -254,5 +254,8 @@ spec:
               path: /diagnostic/status/heartbeat
               port: http
           {{- end }}
+      {{- with .Values.broker.extraContainers }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       volumes:
       {{- toYaml .Values.broker.volumes | nindent 8 }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -481,7 +481,7 @@ externalDatabase:
       username: ""
 
       # -- Password for the non-root username for the Pact Broker
-      password: ""
+      password: null
 
       # -- Name of an existing Kubernetes secret containing the database credentials
       existingSecret: ""

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -352,6 +352,16 @@ broker:
     #   name: <VOLUME_NAME>
     #   readOnly: true
 
+  # -- Additional containers to add to the Pact Broker pods
+  extraContainers: []
+  # extraContainers:
+  #   - name: cloudsql-proxy
+  #     image: gcr.io/cloudsql-docker/gce-proxy:1.22.0
+  #     command:
+  #       - /cloud_sql_proxy
+  #       - '-instances=my-project:my-zone:my-db-name=tcp:5432'
+  #       - '-enable_iam_login'
+
 #  Service configuration
 service:
 


### PR DESCRIPTION
## fixes broken .Values.externalDatabase.config.auth.password
if `.Values.externalDatabase.enabled`, the current chart logic completely ignores `.Values.externalDatabase.config.auth.password` and incorrectly mounts `.Values.externalDatabase.config.auth.existingSecret`