### PR TITLE
feat: ability to run arbitrary sidecar extraContainers

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.7.2
+version: 0.8.0
 appVersion: 2.105.0.1
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -146,6 +146,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | broker.tolerations | Pact Broker [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | list | `[]` |
 | broker.volumeMounts |  | list | `[]` |
 | broker.volumes |  | list | `[]` |
+| broker.extraContainers | Additional containers to add to the Pact Broker pods | list | `[]` |
 | externalDatabase.config.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
 | externalDatabase.config.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |
 | externalDatabase.config.auth.existingSecretPasswordKey | The key to which the password will be stored under within existing secret. | string | `"user-password"` |

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -248,6 +248,9 @@ spec:
               path: /diagnostic/status/heartbeat
               port: http
           {{- end }}
+      {{- with .Values.broker.extraContainers }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       {{- if .Values.broker.nodeSelector }}
       nodeSelector:
       {{- toYaml .Values.broker.nodeSelector | nindent 8 }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -352,6 +352,16 @@ broker:
     #   name: <VOLUME_NAME>
     #   readOnly: true
 
+  # -- Additional containers to add to the Pact Broker pods
+  extraContainers: []
+  # extraContainers:
+  #   - name: cloudsql-proxy
+  #     image: gcr.io/cloudsql-docker/gce-proxy:1.22.0
+  #     command:
+  #       - /cloud_sql_proxy
+  #       - '-instances=my-project:my-zone:my-db-name=tcp:5432'
+  #       - '-enable_iam_login'
+
 #  Service configuration
 service:
 


### PR DESCRIPTION
## adds the ability to run arbitrary sidecar extraContainers
i have a use case where i need to use [cloudsql proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy) to connect the pact broker to a google cloudsql postgres instance.
```yaml
extraContainers:
  - name: cloudsql-proxy
    image: gcr.io/cloudsql-docker/gce-proxy:1.22.0
    command:
      - /cloud_sql_proxy
      - '-instances=my-project:my-zone:my-db-name=tcp:5432'
      - '-enable_iam_login'
```
 another common use cases is running a vault sidecar to inject secrets

test values correctly output a new sidecar
```
        - command:
          - /cloud_sql_proxy
          - -instances=my-project:my-zone:my-db-name=tcp:5432
          - -enable_iam_login
          image: gcr.io/cloudsql-docker/gce-proxy:1.22.0
          name: cloudsql-proxy
```

mostly copied from the common pattern at https://github.com/argoproj/argo-helm/blob/c08fc230d75c85b2c9a07138c5c7b7bc957b98df/charts/argo-cd/templates/argocd-repo-server/deployment.yaml