### PR TITLE
feat: bumped the version of the Pact Broker to 2.112.0-pactbroker2.107.1 (using the new docker tagging naming convention)

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 0.10.1
-appVersion: 2.105.0.1
+version: 0.11.0
+appVersion: 2.107.1
 dependencies:
   - condition: postgresql.enabled
     name: postgresql

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.105.0.1](https://img.shields.io/badge/AppVersion-2.105.0.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.107.1](https://img.shields.io/badge/AppVersion-2.107.1-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 
@@ -162,7 +162,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | image.pullSecrets | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)  Example:   pullSecrets:    - mySecretName  | list | `[]` |
 | image.registry | Pact Broker image registry | string | `"docker.io"` |
 | image.repository | Pact Broker image repository | string | `"pactfoundation/pact-broker"` |
-| image.tag | Pact Broker image tag (immutable tags are recommended) | string | `"2.105.0.1"` |
+| image.tag | Pact Broker image tag (immutable tags are recommended) | string | `"2.112.0-pactbroker2.107.1"` |
 | ingress.annotations | ingress.annotations Additional annotations for the Ingress resource | object | `{}` |
 | ingress.className | ingress.className Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx) | string | `""` |
 | ingress.enabled | ingress.enabled Enable the creation of the ingress resource | bool | `true` |

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: pactfoundation/pact-broker
 
   # -- Pact Broker image tag (immutable tags are recommended)
-  tag: 2.105.0.1
+  tag: 2.112.0-pactbroker2.107.1
 
   # -- Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
feat: bumped the version of the Pact Broker to 2.112.0-pactbroker2.107.1 (using the new docker tagging naming convention)

- https://github.com/pact-foundation/pact-broker-docker
- https://github.com/pact-foundation/pact_broker/releases/tag/v2.107.1