### PR TITLE
Add Ability to Source Username from External Secret

### DIFF
--- a/charts/pact-broker/templates/_helpers.tpl
+++ b/charts/pact-broker/templates/_helpers.tpl
@@ -158,7 +158,16 @@ Database ENV Vars
 - name: PACT_BROKER_DATABASE_NAME
   value: {{ include "broker.databaseName" . }}
 - name: PACT_BROKER_DATABASE_USERNAME
-  value: {{ include "broker.databaseUser" . }}
+  {{- if .Values.postgresql.enabled  }}
+  value: {{ .Values.postgresql.auth.password | quote }}
+  {{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.config.auth.username }}
+  value: {{ .Values.externalDatabase.config.auth.username | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "broker.databaseUserSecretName" . }}
+      key: {{ include "broker.databaseUserSecretKey" . }}
+  {{- end }}
 - name: PACT_BROKER_DATABASE_PASSWORD
   {{- if and .Values.postgresql.enabled .Values.postgresql.auth.password }}
   value: {{ .Values.postgresql.auth.password | quote }}


### PR DESCRIPTION
For databases that use a multi-user rotation strategy usernames and passwords are changed dynamically and we need the ability to source the username from an external secret the same as we do for DB Password.