### PR TITLE
Add labels and annotations from values to the Deployment

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 3.3.3
+version: 3.3.4
 appVersion: 2.112.0
 dependencies:
   - condition: postgresql.enabled

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 3.3.3](https://img.shields.io/badge/Version-3.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
+![Version: 3.3.4](https://img.shields.io/badge/Version-3.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -7,6 +7,15 @@ metadata:
     app.kubernetes.io/name: {{ include "chart.name" . }}
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.broker.labels -}}
+    {{ toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.broker.annotations }}
+  annotations:
+    {{- with .Values.broker.annotations -}}
+    {{ toYaml . | trim | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.broker.replicaCount }}
   {{- if .Values.broker.revisionHistoryLimit }}


### PR DESCRIPTION
Sample output from `helm template . --set "broker.labels.test=test" --set "broker.annotations.test2=test2"`

```
---
# Source: pact-broker/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-pact-broker
  namespace: "default"
  labels:
    app.kubernetes.io/name: pact-broker
    helm.sh/chart: pact-broker
    app.kubernetes.io/instance: release-name
    test: test
  annotations:
    test2: test2
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: pact-broker
  template:
    metadata:
      labels:
        app.kubernetes.io/name: pact-broker
        app.kubernetes.io/instance: release-name
        test: test
      annotations:
        test2: test2
```

They were previously only being added to the pod template, not the actual Deployment.