### PR TITLE
adds pact broker renovate dep updates

### DIFF
--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -178,6 +178,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | postgresql.auth.secretKeys.userPasswordKey | The key in which Postgres well look for, for the user password, in the existing Secret | string | `"user-password"` |
 | postgresql.auth.username | Name for a custom user to create | string | `"bn_broker"` |
 | postgresql.enabled | Switch to enable or disable the PostgreSQL helm chart | bool | `true` |
+| postgresql.image | Change default PostgreSQL image location (workaround for https://github.com/bitnami/charts/issues/35164) | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql"}` |
 | service.annotations | service.annotations Additional annotations for the Service resource | object | `{}` |
 | service.clusterIP | Pact Broker service clusterIP | string | `""` |
 | service.loadBalancerIP | Pact Broker Service [loadBalancerIP](https://kubernetes.io/docs/user-guide/services/#type-loadbalancer) | string | `""` |

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Configure versioning for Pact Broker Docker image",
+      "matchPackageNames": ["pactfoundation/pact-broker"],
+      "matchDatasources": ["docker"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-pactbroker(?<compatibility>.*))?$"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update Pact Broker Docker image version in Helm values",
+      "fileMatch": ["^charts/pact-broker/values\\.yaml$"],
+      "matchStrings": [
+        "# -- Pact Broker image tag \\(immutable tags are recommended\\)\\s+tag:\\s+(?<currentValue>.*?)\\s"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "pactfoundation/pact-broker",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-pactbroker(?<compatibility>.*))?$"
+    }
   ]
 }


### PR DESCRIPTION
# 🔧 Configure Renovate for Pact Broker Docker Image Updates

##  Summary

  Adds custom Renovate configuration to properly detect and update Pact
  Broker Docker image versions that use a non-standard versioning scheme.

##  Problem

  The Pact Broker Docker image uses a custom versioning format:
  `M.m.p-pactbroker<version>` (e.g., `2.124.0-pactbroker2.112.0`). Standard
  Renovate configuration doesn't understand this format, preventing
  automatic dependency updates.

 ## Solution

  Enhanced renovate.json with:
  - Custom regex versioning to parse the M.m.p-pactbroker<version> format
  - Regex manager to detect version updates in
  charts/pact-broker/values.yaml
  - Package rules to apply the custom versioning to the Pact Broker Docker
  image

##  Versioning Scheme Details

  The Docker image follows this pattern:
  - Major (M): Breaking changes, major Pact Broker gem updates,                  incompatible base image changes
  - Minor (m): New non-breaking features, minor Pact Broker gem updates
  - Patch (p): Bug fixes, patch Pact Broker gem updates
  - Suffix (-pactbroker<version>): Informational, indicates the Pact Broker
   gem version


##  Impact

  Renovate will now:
  1. Correctly parse Pact Broker Docker image versions
  2. Create PRs for new image releases following semantic versioning rules
  3. Maintain the special versioning format in values.yaml

 ## Related

  - Pact Broker Docker Hub:
  https://hub.docker.com/r/pactfoundation/pact-broker
  - Previous versioning scheme (deprecated May 2023): M.m.p.RELEASE
