### PR TITLE
Remove PostgreSQL subchart and require external database (v4.0.0)

### DIFF
--- a/.github/ci-postgres.yaml
+++ b/.github/ci-postgres.yaml
@@ -1,0 +1,123 @@
+---
+# PostgreSQL deployment for CI testing
+# This creates a simple PostgreSQL instance in the default namespace
+# for testing the Pact Broker with external database configuration
+# We create:
+# `postgres-config` - a ConfigMap to configure the PostgreSQL instance
+# `postgres-pvc` - a PersistentVolumeClaim for the PostgreSQL data
+# `postgres` - a Deployment for the PostgreSQL instance
+# `postgres` - a Service for the PostgreSQL instance
+# `pact-broker-db-secret` - a Secret for the Pact Broker database password in order
+#                            to be used by the Pact Broker to connect to the database
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: default
+data:
+  POSTGRES_DB: "pactbroker"
+  POSTGRES_USER: "pactbroker"
+  POSTGRES_PASSWORD: "pactbroker-password"
+---
+# Create a secret that the Pact Broker will use
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pact-broker-db-secret
+  namespace: default
+type: Opaque
+stringData:
+  database-password: "pactbroker-password"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5432
+          name: postgres
+        envFrom:
+        - configMapRef:
+            name: postgres-config
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-storage
+          subPath: postgres
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - pactbroker
+            - -d
+            - pactbroker
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - pactbroker
+            - -d
+            - pactbroker
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+    name: postgres

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
       
       - name: Add dependencies
         run: |
+          # Still need bitnami repo for the common chart dependency
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,12 +42,35 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
-     
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
       - name: Create KIND Cluster
         uses: helm/kind-action@7cd7463a0995e35ab5d0f2c119f892514f3a3778 # pin@v1.12.0
+
+      - name: Deploy PostgreSQL for testing
+        run: |
+          kubectl apply -f .github/ci-postgres.yaml
+          echo "Waiting for PostgreSQL to be ready..."
+          kubectl wait --for=condition=ready pod -l app=postgres --timeout=120s
+          echo "PostgreSQL deployment status:"
+          kubectl get pods -l app=postgres
+          kubectl get svc postgres
+
+          # Verify PostgreSQL is accepting connections
+          echo "Verifying PostgreSQL connectivity..."
+          kubectl run postgres-test --image=postgres:15-alpine --rm -i --restart=Never --env="PGPASSWORD=pactbroker-password" -- \
+            psql -h postgres -U pactbroker -d pactbroker -c "SELECT version();" || true
+
+          # Show the secrets created for the Pact Broker
+          echo "Available secrets:"
+          kubectl get secrets pact-broker-db-secret
 
       - name: Run chart-testing (install)
         run: ct install --config ct-install.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres-version: ['13', '14', '15', '16', '17']
+    name: Test with PostgreSQL ${{ matrix.postgres-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -56,16 +60,18 @@ jobs:
 
       - name: Deploy PostgreSQL for testing
         run: |
-          kubectl apply -f .github/ci-postgres.yaml
-          echo "Waiting for PostgreSQL to be ready..."
+          # Replace the PostgreSQL image version in the manifest
+          sed "s/postgres:15-alpine/postgres:${{ matrix.postgres-version }}-alpine/g" .github/ci-postgres.yaml | kubectl apply -f -
+
+          echo "Waiting for PostgreSQL ${{ matrix.postgres-version }} to be ready..."
           kubectl wait --for=condition=ready pod -l app=postgres --timeout=120s
           echo "PostgreSQL deployment status:"
           kubectl get pods -l app=postgres
           kubectl get svc postgres
 
           # Verify PostgreSQL is accepting connections
-          echo "Verifying PostgreSQL connectivity..."
-          kubectl run postgres-test --image=postgres:15-alpine --rm -i --restart=Never --env="PGPASSWORD=pactbroker-password" -- \
+          echo "Verifying PostgreSQL ${{ matrix.postgres-version }} connectivity..."
+          kubectl run postgres-test --image=postgres:${{ matrix.postgres-version }}-alpine --rm -i --restart=Never --env="PGPASSWORD=pactbroker-password" -- \
             psql -h postgres -U pactbroker -d pactbroker -c "SELECT version();" || true
 
           # Show the secrets created for the Pact Broker

--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ We are always looking for maintainers, please let us know if you'd be interested
 
 ## TL;DR
 
-```console
-helm repo add bitnami https://charts.bitnami.com/bitnami
+> **⚠️ IMPORTANT:** As of v4.0.0, you must provide your own PostgreSQL database. The bundled PostgreSQL subchart has been removed. More info can be found [here](https://github.com/pact-foundation/pact-broker-chart/issues/194).
+
+```shell
 helm repo add pact-broker https://pact-foundation.github.io/pact-broker-chart/
 
-helm install pact-broker pact-broker/pact-broker
+# Install with external database configuration
+helm install pact-broker pact-broker/pact-broker \
+  --set database.host=your-postgres-host \
+  --set database.databaseName=pactbroker \
+  --set database.auth.username=pactbroker \
+  --set database.auth.password=your-password
 ```
 
 ## Usage
@@ -44,7 +50,11 @@ Charts are also available in OCI format. The list of available charts can be fou
 Install one of the available charts:
 
 ```shell
-helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/pact-broker --version=<version>
+helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/pact-broker --version=<version> \
+  --set database.host=your-postgres-host \
+  --set database.databaseName=pactbroker \
+  --set database.auth.username=pactbroker \
+  --set database.auth.password=your-password
 ```
 
 ## Contributing

--- a/charts/pact-broker/Chart.lock
+++ b/charts/pact-broker/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.24
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.4
-digest: sha256:682f1eaee08475822560e364fd7dc8e7240db0e60778e4f2237163cba9a4e10d
-generated: "2025-08-13T22:12:50.953543239Z"
+digest: sha256:4ae0a824a540bb50b58534cc15aa30a677c33334a45301a1772845a535cedf7b
+generated: "2025-10-26T16:58:26.486047Z"

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,13 +2,9 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 3.3.5
+version: 4.0.0
 appVersion: 2.112.0
 dependencies:
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 16.7.24
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     tags:

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 3.3.5](https://img.shields.io/badge/Version-3.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 
@@ -52,7 +52,6 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | Repository | Name | Version |
 |------------|------|---------|
 | oci://registry-1.docker.io/bitnamicharts | common | 2.31.4 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.7.24 |
 
 ## Values
 
@@ -149,15 +148,14 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | broker.tolerations | Pact Broker [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | list | `[]` |
 | broker.volumeMounts | Volume mounts | list | `[]` |
 | broker.volumes | Volumes to mount | list | `[]` |
-| externalDatabase.config.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
-| externalDatabase.config.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |
-| externalDatabase.config.auth.existingSecretPasswordKey | The key to which the password will be stored under within existing secret. | string | `"user-password"` |
-| externalDatabase.config.auth.password | Password for the non-root username for the Pact Broker | string | `""` |
-| externalDatabase.config.auth.username | Non-root username for the Pact Broker | string | `""` |
-| externalDatabase.config.databaseName | External database name | string | `""` |
-| externalDatabase.config.host | Database host | string | `""` |
-| externalDatabase.config.port | Database port number | string | `""` |
-| externalDatabase.enabled | Switch to enable or disable the externalDatabase connection | bool | `false` |
+| database.adapter | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) | string | `""` |
+| database.auth.existingSecret | Name of an existing Kubernetes secret containing the database credentials | string | `""` |
+| database.auth.existingSecretPasswordKey | The key to which the password will be stored under within existing secret. | string | `"user-password"` |
+| database.auth.password | Password for the non-root username for the Pact Broker | string | `""` |
+| database.auth.username | Non-root username for the Pact Broker | string | `""` |
+| database.databaseName | External database name | string | `""` |
+| database.host | Database host | string | `""` |
+| database.port | Database port number | string | `""` |
 | image.pullPolicy | Specify a imagePullPolicy Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)  | string | `"IfNotPresent"` |
 | image.pullSecrets | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)  Example:   pullSecrets:    - mySecretName  | list | `[]` |
 | image.registry | Pact Broker image registry | string | `"docker.io"` |
@@ -169,16 +167,6 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | ingress.host | host Hostname to be used to expose the route to access the Pact Broker | string | `""` |
 | ingress.tls.enabled | ingress.tls.enabled Enable TLS configuration for the host defined at `ingress.host` parameter | bool | `false` |
 | ingress.tls.secretName | ingress.tls.secretName The name to which the TLS Secret will be called | string | `""` |
-| postgresql.architecture | PostgreSQL architecture (`standalone` or `replication`) | string | `"standalone"` |
-| postgresql.auth.database | Name for a custom database to create | string | `"bitnami_broker"` |
-| postgresql.auth.existingSecret | Name of existing secret to use for PostgreSQL credentials | string | `""` |
-| postgresql.auth.password | Password for the custom user to create | string | `""` |
-| postgresql.auth.secretKeys.adminPasswordKey | The key in which Postgres well look for, for the admin password, in the existing Secret | string | `"admin-password"` |
-| postgresql.auth.secretKeys.replicationPasswordKey | The key in which Postgres well look for, for the replication password, in the existing Secret | string | `"replication-password"` |
-| postgresql.auth.secretKeys.userPasswordKey | The key in which Postgres well look for, for the user password, in the existing Secret | string | `"user-password"` |
-| postgresql.auth.username | Name for a custom user to create | string | `"bn_broker"` |
-| postgresql.enabled | Switch to enable or disable the PostgreSQL helm chart | bool | `true` |
-| postgresql.image | Change default PostgreSQL image location (workaround for https://github.com/bitnami/charts/issues/35164) | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql"}` |
 | service.annotations | service.annotations Additional annotations for the Service resource | object | `{}` |
 | service.clusterIP | Pact Broker service clusterIP | string | `""` |
 | service.loadBalancerIP | Pact Broker Service [loadBalancerIP](https://kubernetes.io/docs/user-guide/services/#type-loadbalancer) | string | `""` |
@@ -196,38 +184,30 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 
 ## Configuration and Installation Details
 
-### Configuring Chart PostgreSQL
+### Database Configuration
 
-With the Pact Broker Helm Chart, it bundles together the Pact Broker and a Bitnami PostgreSQL database - this can be enabled by switching `postgresql.enabled` to true (it is `true` by default). If switched on, the Helm Chart, on deployment, will automatically deploy a PostgreSQL instance and configure it with the credentials you specify. There are multiple ways of doing this that will be detailed below.
+> **⚠️ BREAKING CHANGE in v4.0.0:** The bundled PostgreSQL subchart has been removed due to licensing changes. You must now provide your own PostgreSQL instance.
 
-#### Automatic Database Credential Creation
-This is the easiest of the configuration options. Here, the credentials for both the Admin and Database user will be automatically generated and put into a Kubernetes secret. This then will be automatically used by the Pact Broker. For this, ensure the following happens:
-  - Keep `postgresql.auth.existingSecret` & `postgresql.auth.password` empty.
+Starting with version 4.0.0, this Helm chart requires an external PostgreSQL database. You can use:
+- Cloud-managed databases (AWS RDS, Google Cloud SQL, Azure Database for PostgreSQL)
+- Self-hosted PostgreSQL instances
+- Kubernetes operators (CloudNativePG, Zalando PostgreSQL Operator)
+- Any PostgreSQL-compatible database
 
-#### Specifying Password for PostgreSQL to Use
-Here, you can specify the password that you want PostgreSQL to use for it's Database User (The user that the Pact Broker will use to connect to the database). For this, ensure the following happens:
-  - Keep the `postgresql.auth.existingSecret` empty.
-  - Set the `postgresql.auth.password` to the value that you want the User password to be.
-  > **_NOTE:_** Be careful and mindful that the value you provide here is done in a secure way.
+Configure the database connection by setting the following values:
+- `database.host` - Database hostname or IP address
+- `database.port` - Database port (defaults to 5432)
+- `database.adapter` - Database adapter (defaults to "postgres", can also be "sqlite")
+- `database.databaseName` - Name of the database
 
-#### Specifying Existing Secret for PostgreSQL to Use
-Here, you can specify an existing Kubernetes secret that you have created that contains the Password that you want PostgreSQL to use. The secret has to be in the same namespace as where you are deploying the Helm Chart. For this, ensure the following happens:
-  - Create the Kubernetes secret with the Password inside.
-  - Set `postgresql.auth.existingSecret` to the name of the Secret
-  - PostgreSQL by default will look for the relevant Password keys that are set by default here `postgresql.auth.secretKeys`. So make sure that the Keys in the Secret match the default `secretKeys` values. More information [here](https://artifacthub.io/packages/helm/bitnami/postgresql)
-  - For example, if you want PostgreSQL to use an existing Secret called `my-user-secret` that has the User password that you want to use inside it. Make sure that you create a Key inside that secret called `user-password` (this key can be found here `postgresql.auth.secretKeys.userPasswordKey`). i.e. `user-password=Password123`.
-
-### Configuring External Database
-If you want to use an external database with your Pact Broker, switch the `externalDatabase.enabled` flag to true and the `postgresql.enabled` to false.
-
-The configuring of the `externalDatabase.config.host`, `externalDatabase.config.port`, `externalDatabase.config.adapter` and `externalDatabase.config.databaseName` should be pretty straight forward. The credential configuration however has two methods of configuration.
+The credential configuration has two methods:
 
 #### Specify Credentials via Values
-Configure the Pact Broker by using the username credential that you configure via the `externalDatabase.config.auth.username` value and the password via the `externalDatabase.config.auth.password` value.
+Configure the Pact Broker by using the username credential that you configure via the `database.auth.username` value and the password via the `database.auth.password` value.
   > **_NOTE:_** Be careful and mindful that the values you provide here is done in a secure way.
 
 #### Specify Credentials via Secret
-Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `externalDatabase.config.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.
+Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `database.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.
 
 ### Database Clean Task
 Pact Broker [automatic data cleanup](https://docs.pact.io/pact_broker/docker_images/pactfoundation#automatic-data-clean-up) can be enabled by setting the property `broker.config.databaseClean.enabled` to `true`.

--- a/charts/pact-broker/README.md.gotmpl
+++ b/charts/pact-broker/README.md.gotmpl
@@ -56,38 +56,30 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 
 ## Configuration and Installation Details
 
-### Configuring Chart PostgreSQL
+### Database Configuration
 
-With the Pact Broker Helm Chart, it bundles together the Pact Broker and a Bitnami PostgreSQL database - this can be enabled by switching `postgresql.enabled` to true (it is `true` by default). If switched on, the Helm Chart, on deployment, will automatically deploy a PostgreSQL instance and configure it with the credentials you specify. There are multiple ways of doing this that will be detailed below.
+> **⚠️ BREAKING CHANGE in v4.0.0:** The bundled PostgreSQL subchart has been removed due to licensing changes. You must now provide your own PostgreSQL instance.
 
-#### Automatic Database Credential Creation
-This is the easiest of the configuration options. Here, the credentials for both the Admin and Database user will be automatically generated and put into a Kubernetes secret. This then will be automatically used by the Pact Broker. For this, ensure the following happens:
-  - Keep `postgresql.auth.existingSecret` & `postgresql.auth.password` empty.
+Starting with version 4.0.0, this Helm chart requires an external PostgreSQL database. You can use:
+- Cloud-managed databases (AWS RDS, Google Cloud SQL, Azure Database for PostgreSQL)
+- Self-hosted PostgreSQL instances
+- Kubernetes operators (CloudNativePG, Zalando PostgreSQL Operator)
+- Any PostgreSQL-compatible database
 
-#### Specifying Password for PostgreSQL to Use
-Here, you can specify the password that you want PostgreSQL to use for it's Database User (The user that the Pact Broker will use to connect to the database). For this, ensure the following happens:
-  - Keep the `postgresql.auth.existingSecret` empty.
-  - Set the `postgresql.auth.password` to the value that you want the User password to be.
-  > **_NOTE:_** Be careful and mindful that the value you provide here is done in a secure way.
+Configure the database connection by setting the following values:
+- `database.host` - Database hostname or IP address
+- `database.port` - Database port (defaults to 5432)
+- `database.adapter` - Database adapter (defaults to "postgres", can also be "sqlite")
+- `database.databaseName` - Name of the database
 
-#### Specifying Existing Secret for PostgreSQL to Use
-Here, you can specify an existing Kubernetes secret that you have created that contains the Password that you want PostgreSQL to use. The secret has to be in the same namespace as where you are deploying the Helm Chart. For this, ensure the following happens:
-  - Create the Kubernetes secret with the Password inside.
-  - Set `postgresql.auth.existingSecret` to the name of the Secret
-  - PostgreSQL by default will look for the relevant Password keys that are set by default here `postgresql.auth.secretKeys`. So make sure that the Keys in the Secret match the default `secretKeys` values. More information [here](https://artifacthub.io/packages/helm/bitnami/postgresql)
-  - For example, if you want PostgreSQL to use an existing Secret called `my-user-secret` that has the User password that you want to use inside it. Make sure that you create a Key inside that secret called `user-password` (this key can be found here `postgresql.auth.secretKeys.userPasswordKey`). i.e. `user-password=Password123`.
-
-### Configuring External Database
-If you want to use an external database with your Pact Broker, switch the `externalDatabase.enabled` flag to true and the `postgresql.enabled` to false.
-
-The configuring of the `externalDatabase.config.host`, `externalDatabase.config.port`, `externalDatabase.config.adapter` and `externalDatabase.config.databaseName` should be pretty straight forward. The credential configuration however has two methods of configuration.
+The credential configuration has two methods:
 
 #### Specify Credentials via Values
-Configure the Pact Broker by using the username credential that you configure via the `externalDatabase.config.auth.username` value and the password via the `externalDatabase.config.auth.password` value.
+Configure the Pact Broker by using the username credential that you configure via the `database.auth.username` value and the password via the `database.auth.password` value.
   > **_NOTE:_** Be careful and mindful that the values you provide here is done in a secure way.
 
 #### Specify Credentials via Secret
-Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `externalDatabase.config.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.
+Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `database.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.
 
 ### Database Clean Task
 Pact Broker [automatic data cleanup](https://docs.pact.io/pact_broker/docker_images/pactfoundation#automatic-data-clean-up) can be enabled by setting the property `broker.config.databaseClean.enabled` to `true`.

--- a/charts/pact-broker/ci/default-values.yaml
+++ b/charts/pact-broker/ci/default-values.yaml
@@ -1,0 +1,10 @@
+# CI test values for the Pact Broker deployment when using an external database
+# with credentials that are specified in the values file.
+database:
+  host: "postgres.default.svc.cluster.local"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    password: "pactbroker-password"

--- a/charts/pact-broker/ci/external-database-with-secret-values.yaml
+++ b/charts/pact-broker/ci/external-database-with-secret-values.yaml
@@ -1,0 +1,12 @@
+# CI test values for the Pact Broker deployment when using an external database
+# with credentials that are specified in a Kubernetes secret.
+database:
+  host: "postgres.default.svc.cluster.local"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    # Using existing Kubernetes secret for password (created in ci-postgres.yaml)
+    existingSecret: "pact-broker-db-secret"
+    existingSecretPasswordKey: "database-password"

--- a/charts/pact-broker/ci/postgres-generated-creds-values.yaml
+++ b/charts/pact-broker/ci/postgres-generated-creds-values.yaml
@@ -1,8 +1,0 @@
-postgresql:
-  enabled: true
-
-  # we enable postgres and allow the subchart to automatically generate the credentials
-  # that backstage will use
-  auth:
-    existingSecret: ""
-    password: ""

--- a/charts/pact-broker/ci/postgres-provided-creds-values.yaml
+++ b/charts/pact-broker/ci/postgres-provided-creds-values.yaml
@@ -1,8 +1,0 @@
-postgresql:
-  enabled: true
-
-  auth:
-    existingSecret: ""
-    # we provide a password for the subchart to use.
-    # this is just a password for purposes of CI tests
-    password: "mytestpassword"

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -430,83 +430,39 @@ ingress:
     # -- ingress.tls.secretName The name to which the TLS Secret will be called
     secretName: ""
 
-# PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)
-postgresql:
+# Database configuration
+# Note: As of v4.0.0, only external databases are supported. The bundled PostgreSQL subchart has been removed.
+# You must provide your own PostgreSQL instance (cloud-managed, self-hosted, or via an operator).
+# Examples: AWS RDS, Google Cloud SQL, Azure Database, or self-managed PostgreSQL
+database:
 
-  # -- Switch to enable or disable the PostgreSQL helm chart
-  enabled: true
+  # -- Database host
+  host: ""
 
-    # -- Change default PostgreSQL image location (workaround for https://github.com/bitnami/charts/issues/35164)
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
+  # -- Database port number
+  port: ""
 
-  # The authentication details of the Postgres database
+  # -- Database engine to use.
+  # Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started)
+  adapter: ""
+
+  # -- External database name
+  databaseName: ""
+
+  # External database auth details that the Pact Broker will use to connect
   auth:
 
-    # -- Name for a custom user to create
-    username: bn_broker
+    # -- Non-root username for the Pact Broker
+    username: ""
 
-    # -- Password for the custom user to create
+    # -- Password for the non-root username for the Pact Broker
     password: ""
 
-    # -- Name for a custom database to create
-    database: bitnami_broker
-
-    # -- Name of existing secret to use for PostgreSQL credentials
+    # -- Name of an existing Kubernetes secret containing the database credentials
     existingSecret: ""
 
-    # The secret keys Postgres will look for to retrieve the relevant password
-    secretKeys:
-
-      # -- The key in which Postgres well look for, for the admin password, in the existing Secret
-      adminPasswordKey: admin-password
-
-      # -- The key in which Postgres well look for, for the user password, in the existing Secret
-      userPasswordKey: user-password
-
-      # -- The key in which Postgres well look for, for the replication password, in the existing Secret
-      replicationPasswordKey: replication-password
-
-  # -- PostgreSQL architecture (`standalone` or `replication`)
-  architecture: standalone
-
-# External database configuration
-externalDatabase:
-
-  # -- Switch to enable or disable the externalDatabase connection
-  enabled: false
-
-  # External Database Configuration
-  config:
-
-    # -- Database host
-    host: ""
-
-    # -- Database port number
-    port: ""
-
-    # -- Database engine to use.
-    # Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started)
-    adapter: ""
-
-    # -- External database name
-    databaseName: ""
-
-    # External database auth details that the Pact Broker will use to connect
-    auth:
-
-      # -- Non-root username for the Pact Broker
-      username: ""
-
-      # -- Password for the non-root username for the Pact Broker
-      password: ""
-
-      # -- Name of an existing Kubernetes secret containing the database credentials
-      existingSecret: ""
-
-      # -- The key to which the password will be stored under within existing secret.
-      existingSecretPasswordKey: "user-password"
+    # -- The key to which the password will be stored under within existing secret.
+    existingSecretPasswordKey: "user-password"
 
 # Service Account Configuration
 serviceAccount:

--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -3,3 +3,4 @@ chart-dirs:
 validate-maintainers: false
 remote: origin
 target-branch: master
+namespace: default

--- a/docs/MIGRATION_GUIDE_v4.md
+++ b/docs/MIGRATION_GUIDE_v4.md
@@ -1,0 +1,114 @@
+# Migration Guide: Upgrading to Pact Broker Helm Chart v4.0.0
+
+## Overview
+
+Version 4.0.0 of the Pact Broker Helm Chart introduces a **breaking change**: the removal of the bundled PostgreSQL subchart. This change was necessary due to Bitnami's decision to discontinue its Helm charts and container images as free open-source offerings.
+
+Users must now provide their own PostgreSQL database instance when deploying the Pact Broker.
+
+## Why This Change?
+
+- **Licensing Changes**: Bitnami has moved away from providing free open-source Helm charts and container images
+- **No Suitable Replacements**: There are no strong, like-for-like replacements for Bitnami's PostgreSQL chart that offer the same level of maintenance and reliability
+- **Production Best Practices**: Most production deployments already use managed PostgreSQL services from cloud providers, making the bundled database less necessary
+- **Reduced Complexity**: Removing the subchart simplifies the Helm chart and reduces maintenance overhead
+
+## Migration Steps
+
+### Scenario 1: Already Using External Database
+
+If you are already using an external database, you'll only need to update the value field names. This can be done as follows:
+
+Change
+```yaml
+externalDatabase:
+  enabled: true
+  config:
+    host: "your.new.postgres.host"
+    port: "5432"
+    adapter: "postgres"
+    databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    existingSecret: "pact-broker-db-secret"
+    existingSecretPasswordKey: "database-password"
+```
+
+To
+```yaml
+database:
+  host: "your.new.postgres.host"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    existingSecret: "pact-broker-db-secret"
+    existingSecretPasswordKey: "database-password"
+```
+
+### Scenario 2: Migrate from Chart Provisioned Database with Value Driven Database Auth Credentials
+
+If you were using the chart provisioned database, and used the values to contain the config for the database, ensure that you take a backup of the data of the database and restore it to your new postgres database. 
+
+> Note: Using plain values should only be done in production if you are using tools such as Bitnami Sealed secrets or SOPS. Unless you are doing this, you should not put credentials in values files and should instead use Kubernetes secrets (scenario below)
+
+Once this has been done, apply the following changes:
+
+Change
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    username: bn_broker
+    password: "my-password"
+    database: pactbroker
+```
+
+To
+
+```yaml
+database:
+  host: "your.new.postgres.host"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "new-username"
+    password: "new-password"
+```
+
+### Scenario 2: Migrate from Chart Provisioned Database with Kubernetes Secrets Driven Auth Credentials
+
+If you were using the chart provisioned database, and used Kubernetes secrets to contain the authentication credentials for connection to the database, ensure that you take a backup of the data of the database and restore it to your new postgres database.
+
+Once this has been done, apply the following changes:
+
+Change
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    username: pactbroker
+    database: pactbroker
+    existingSecret: "pact-broker-db-secret"
+    secretKeys:
+      userPasswordKey: database-password
+    
+```
+
+To
+
+```yaml
+database:
+  host: "postgres.example.com"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    existingSecret: "pact-broker-db-secret"
+    existingSecretPasswordKey: "database-password"
+```


### PR DESCRIPTION
# ⚠️  Breaking Change ⚠️

  This PR removes the bundled PostgreSQL subchart from the Pact Broker Helm chart, making this a major version bump to v4.0.0. Users must now provide their own PostgreSQL instance.

 ## Background

  Due to Bitnami's decision to discontinue free open-source Helm charts and container images, we've removed the PostgreSQL subchart dependency. After evaluation, we found no suitable drop-in replacements that match Bitnami's quality and maintenance standards.

 ## Changes

  - Removed PostgreSQL subchart - No longer bundles PostgreSQL with the chart
  - Simplified configuration - Renamed externalDatabase to database as it's now the only option
  - Updated templates - Removed all conditional logic for PostgreSQL vs external database
  - Enhanced CI testing - Added PostgreSQL deployment to Kind cluster for testing
  - Matrix testing - Tests against PostgreSQL versions 13, 14, 15, 16, and 17
  - Migration guide - Added comprehensive guide for users upgrading

##  Migration Required

  Users upgrading must:
  1. Deploy their own PostgreSQL instance (cloud-managed, self-hosted, or via operator)
  2. Update their values to use the new database configuration structure
  3. Migrate data from the bundled PostgreSQL if previously used

  See [./docs/MIGRATION_GUIDE_v4.md](https://github.com/pact-foundation/pact-broker-chart/blob/master/docs/MIGRATION_GUIDE_v4.md) for detailed upgrade instructions.

 ## Rationale

  - Most production deployments already use managed PostgreSQL services
  - Removes maintenance burden and security concerns of bundled database
  - Aligns with cloud-native best practices of using external stateful services
  - Simplifies the chart and reduces complexity

Fixes #194