### PR TITLE
Breaking Change:  Moves Broker Image settings

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 4.0.0
+version: 5.0.0
 appVersion: 2.112.0
 dependencies:
   - name: common

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -122,6 +122,9 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | broker.containerSecurityContext.runAsNonRoot | Set Pact Broker container's Security Context runAsNonRoot | bool | `true` |
 | broker.containerSecurityContext.runAsUser | Set Pact Broker container's Security Context runAsUser | int | `1001` |
 | broker.extraContainers | Additional containers to add to the Pact Broker pods | list | `[]` |
+| broker.image | Pact Broker image url | string | `"docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0"` |
+| broker.imagePullPolicy | Specify a imagePullPolicy Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)  | string | `"IfNotPresent"` |
+| broker.imagePullSecrets | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)  Example:   pullSecrets:    - mySecretName  | list | `[]` |
 | broker.labels | Additional labels that can be added to the Broker deployment | object | `{}` |
 | broker.livenessProbe.enabled | Enable livenessProbe on Pact Broker containers | bool | `true` |
 | broker.livenessProbe.failureThreshold | Failure threshold for livenessProbe | int | `3` |
@@ -156,11 +159,6 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | database.databaseName | External database name | string | `""` |
 | database.host | Database host | string | `""` |
 | database.port | Database port number | string | `""` |
-| image.pullPolicy | Specify a imagePullPolicy Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)  | string | `"IfNotPresent"` |
-| image.pullSecrets | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)  Example:   pullSecrets:    - mySecretName  | list | `[]` |
-| image.registry | Pact Broker image registry | string | `"docker.io"` |
-| image.repository | Pact Broker image repository | string | `"pactfoundation/pact-broker"` |
-| image.tag | Pact Broker image tag (immutable tags are recommended) | string | `"2.124.0-pactbroker2.112.0"` |
 | ingress.annotations | ingress.annotations Additional annotations for the Ingress resource | object | `{}` |
 | ingress.className | ingress.className Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx) | string | `""` |
 | ingress.enabled | ingress.enabled Enable the creation of the ingress resource | bool | `true` |

--- a/charts/pact-broker/templates/_helpers.tpl
+++ b/charts/pact-broker/templates/_helpers.tpl
@@ -29,10 +29,7 @@ This allows us to not have image: .Values.xxxx.ssss/.Values.xxx.xxx:.Values.ssss
 in every single template.
 */}}
 {{- define "broker.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $imageName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag -}}
-{{- printf "%s/%s:%s" $registryName $imageName $tag -}}
+{{- .Values.broker.image -}}
 {{- end -}}
 
 {{/*

--- a/charts/pact-broker/templates/cronjob.yml
+++ b/charts/pact-broker/templates/cronjob.yml
@@ -19,7 +19,7 @@ spec:
           containers:
             - name: {{ template "chart.fullname" . }}-dbclean
               image: {{ template "broker.image" . }}
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              imagePullPolicy: {{ .Values.broker.imagePullPolicy }}
               command:
                 - clean
               env:

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -42,9 +42,9 @@ spec:
     spec:
       serviceAccountName: {{ include "broker.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-      {{- if .Values.image.pullSecrets }}
+      {{- if .Values.broker.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
+      {{- range .Values.broker.imagePullSecrets }}
         - name: {{ . }}
       {{- end }}
       {{- end }}
@@ -54,7 +54,7 @@ spec:
       containers:
         - name: {{ template "chart.fullname" . }}
           image: {{ template "broker.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.broker.imagePullPolicy }}
           {{- if .Values.broker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.broker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -1,20 +1,14 @@
-# Pact Broker image information
-image:
+# Broker configuration
+broker:
 
-  # -- Pact Broker image registry
-  registry: docker.io
-
-  # -- Pact Broker image repository
-  repository: pactfoundation/pact-broker
-
-  # -- Pact Broker image tag (immutable tags are recommended)
-  tag: 2.124.0-pactbroker2.112.0
+  # -- Pact Broker image url
+  image: docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0
 
   # -- Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)
   #
-  pullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
 
   # -- Array of imagePullSecrets to allow pulling the Pact Broker image from private registries.
   # PS: Secret's must exist in the namespace to which you deploy the Pact Broker.
@@ -24,10 +18,7 @@ image:
   #   pullSecrets:
   #    - mySecretName
   #
-  pullSecrets: []
-
-# Broker configuration
-broker:
+  imagePullSecrets: []
 
   # -- Additional labels that can be added to the Broker deployment
   labels: {}

--- a/docs/MIGRATION_GUIDE_v5.md
+++ b/docs/MIGRATION_GUIDE_v5.md
@@ -1,0 +1,57 @@
+# Migration Guide: Image Settings Changes in v5.0.0
+
+## Overview
+
+Version 5.0.0 of the Pact Broker Helm Chart reorganizes the image configuration settings. The image-related values have been moved from the top-level `image` object into the `broker` object for better logical organization of chart values.
+
+This is a **breaking change** that requires updating your values files when upgrading from v4.x to v5.0.0.
+
+## What Changed
+
+### Previous Structure (v4.x and earlier)
+
+```yaml
+# Top-level image configuration
+image:
+  registry: docker.io
+  repository: pactfoundation/pact-broker
+  tag: 2.124.0-pactbroker2.112.0
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# Separate broker configuration
+broker:
+  labels: {}
+  annotations: {}
+  # ... other broker settings
+```
+
+### New Structure (v5.0.0)
+
+```yaml
+# All image settings now under broker
+broker:
+  # Single image URL combining registry, repository, and tag
+  image: docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0
+
+  # Renamed from pullPolicy to imagePullPolicy
+  imagePullPolicy: IfNotPresent
+
+  # Renamed from pullSecrets to imagePullSecrets
+  imagePullSecrets: []
+
+  # Other broker settings remain the same
+  labels: {}
+  annotations: {}
+  # ... other broker settings
+```
+
+## Key Changes
+
+1. **Image URL Format**: The separate `registry`, `repository`, and `tag` fields have been consolidated into a single `image` field containing the full image URL.
+
+2. **Field Renaming**:
+   - `pullPolicy` → `imagePullPolicy`
+   - `pullSecrets` → `imagePullSecrets`
+
+3. **Location**: All image-related settings are now nested under the `broker` object instead of being at the top level.


### PR DESCRIPTION
# ⚠️  Breaking Change ⚠️ 

## Key Changes

1. **Image URL Format**: The separate `registry`, `repository`, and `tag` fields have been consolidated into a single `image` field containing the full image URL to make automated dependency bumps easier.

2. **Field Renaming**:
   - `pullPolicy` → `imagePullPolicy`
   - `pullSecrets` → `imagePullSecrets`

3. **Location**: All image-related settings are now nested under the `broker` object instead of being at the top level.

If you used any of the fields below, make sure you change them to the new variants.

### Before:
```yaml
image:
  registry: docker.io
  repository: pactfoundation/pact-broker
  tag: 2.124.0-pactbroker2.112.0
  pullPolicy: IfNotPresent
  pullSecrets: []
```

### After:
```yaml
broker:
   image: docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
```

More information on the [v5 migration guide](./docs/MIGRATION_GUIDE_v5.md)

