### PR TITLE
adds renovate config for automatic bumps and switches to ghcr

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 5.0.0
+version: 5.1.0
 appVersion: 2.112.0
 dependencies:
   - name: common

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -122,7 +122,7 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | broker.containerSecurityContext.runAsNonRoot | Set Pact Broker container's Security Context runAsNonRoot | bool | `true` |
 | broker.containerSecurityContext.runAsUser | Set Pact Broker container's Security Context runAsUser | int | `1001` |
 | broker.extraContainers | Additional containers to add to the Pact Broker pods | list | `[]` |
-| broker.image | Pact Broker image url | string | `"docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0"` |
+| broker.image | Pact Broker image url | string | `"ghcr.io/pact-foundation/pact-broker:2.124.0-pactbroker2.112.0"` |
 | broker.imagePullPolicy | Specify a imagePullPolicy Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)  | string | `"IfNotPresent"` |
 | broker.imagePullSecrets | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)  Example:   pullSecrets:    - mySecretName  | list | `[]` |
 | broker.labels | Additional labels that can be added to the Broker deployment | object | `{}` |

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.112.0](https://img.shields.io/badge/AppVersion-2.112.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -2,7 +2,7 @@
 broker:
 
   # -- Pact Broker image url
-  image: docker.io/pactfoundation/pact-broker:2.124.0-pactbroker2.112.0
+  image: ghcr.io/pact-foundation/pact-broker:2.124.0-pactbroker2.112.0
 
   # -- Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/docs/RENOVATE_VERSIONING.md
+++ b/docs/RENOVATE_VERSIONING.md
@@ -1,0 +1,144 @@
+# Renovate Configuration for Pact Broker Double Versioning
+
+## The Challenge: Compound Version Numbers
+
+The Pact Broker Docker images use a compound versioning scheme that includes two separate version numbers:
+
+```
+2.124.0-pactbroker2.112.0
+│       │          │
+│       │          └── Pact Broker Ruby Gem version
+│       └──────────────── Hyphen separator with "pactbroker" prefix
+└──────────────────────── Docker image version
+```
+
+### Version Progression Example
+
+Here's how the versions have progressed:
+- `2.120.0-pactbroker2.110.0`
+- `2.124.0-pactbroker2.112.0` (current)
+- `2.125.0-pactbroker2.113.0` (both parts updated)
+- `2.126.0-pactbroker2.113.0` (only Docker version updated)
+- `2.127.0-pactbroker2.113.2` (gem patch version update)
+- `2.128.0-pactbroker2.114.0` (both parts updated)
+- `2.133.0-pactbroker2.116.0` (latest)
+
+## The Problem
+
+Standard semantic versioning (semver) doesn't handle this dual-version format well because:
+1. The version contains two independent version numbers
+2. Either part can be updated independently
+3. Version comparison needs to consider both parts hierarchically
+
+## The Solution: Loose Versioning
+
+We've configured Renovate to use **"loose" versioning** instead of strict regex versioning. This approach:
+
+1. **More Flexible Parsing**: Loose versioning can handle non-standard version formats
+2. **Natural Ordering**: It understands that `2.125.0-pactbroker2.113.0` > `2.124.0-pactbroker2.112.0`
+3. **Handles Both Components**: Properly compares the full version string
+
+### Configuration
+
+```json
+{
+  "packageRules": [
+    {
+      "description": "Configure versioning for Pact Broker Docker image",
+      "matchPackageNames": [
+        "ghcr.io/pact-foundation/pact-broker"
+      ],
+      "matchDatasources": ["docker"],
+      "versioning": "loose"  // ← Key change: using "loose" instead of regex
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "matchStrings": [
+        "image: ghcr\\.io/pact-foundation/pact-broker:(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+-pactbroker[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "versioningTemplate": "loose"  // ← Also using "loose" here
+    }
+  ]
+}
+```
+
+## How Loose Versioning Works
+
+Loose versioning:
+1. Splits the version string into comparable segments
+2. Compares numeric parts numerically
+3. Compares string parts alphabetically
+4. Handles pre-release identifiers correctly
+
+For `2.124.0-pactbroker2.112.0` vs `2.125.0-pactbroker2.113.0`:
+1. First compares `2.124.0` vs `2.125.0` → 2.125.0 is newer
+2. If equal, would then compare the suffix parts
+
+## Testing the Configuration
+
+### Local Testing (Limited)
+```bash
+# Run renovate locally (won't fetch remote versions)
+renovate --platform=local
+
+# With debug output
+LOG_LEVEL=debug renovate --platform=local
+```
+
+### Full Testing (Requires GitHub Token)
+```bash
+# Set your GitHub token
+export GITHUB_TOKEN=your_github_token_here
+
+# Run against the repository
+renovate --platform=github --repository=your-org/pact-broker-chart
+```
+
+## Expected Behavior
+
+With this configuration, Renovate should:
+1. ✅ Detect the current version: `2.124.0-pactbroker2.112.0`
+2. ✅ Fetch available versions from GitHub Container Registry
+3. ✅ Recognize `2.133.0-pactbroker2.116.0` as newer
+4. ✅ Create a PR to update the image version
+
+## Alternative Approaches (If Loose Versioning Fails)
+
+### Option 1: Custom Regex with Explicit Version Parts
+```json
+{
+  "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-pactbroker(?<compatibility>\\d+\\.\\d+\\.\\d+)$",
+  "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+-pactbroker\\d+\\.\\d+\\.\\d+)$"
+}
+```
+
+### Option 2: Docker Versioning
+```json
+{
+  "versioning": "docker"
+}
+```
+Docker versioning understands tags with hyphens and might handle this format.
+
+### Option 3: Treat Entire String as Version
+```json
+{
+  "versioning": "regex:^(?<version>.+)$"
+}
+```
+This treats the entire string as an opaque version for string comparison.
+
+## Monitoring Updates
+
+To verify Renovate is working:
+1. Check the Renovate dashboard/logs after deployment
+2. Look for created PRs with title like "Update ghcr.io/pact-foundation/pact-broker"
+3. Verify the PR updates both version components correctly
+
+## References
+
+- [Renovate Versioning Schemes](https://docs.renovatebot.com/modules/versioning/)
+- [Loose Versioning Documentation](https://docs.renovatebot.com/modules/versioning/#loose)
+- [Pact Broker Releases](https://github.com/pact-foundation/pact-broker-docker/releases)

--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,12 @@
     {
       "description": "Configure versioning for Pact Broker Docker image",
       "matchPackageNames": [
-        "pactfoundation/pact-broker"
+        "ghcr.io/pact-foundation/pact-broker"
       ],
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-pactbroker(?<compatibility>.*))?$"
+      "versioning": "loose"
     }
   ],
   "customManagers": [
@@ -20,14 +20,14 @@
       "customType": "regex",
       "description": "Update Pact Broker Docker image version in Helm values",
       "managerFilePatterns": [
-        "/^charts/pact-broker/values\\.yaml$/"
+        "charts/pact-broker/values\\.yaml"
       ],
       "matchStrings": [
-        "repository: pactfoundation/pact-broker[\\s\\S]*?tag: (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+-pactbroker[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "image: ghcr\\.io/pact-foundation/pact-broker:(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+-pactbroker[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],
       "datasourceTemplate": "docker",
-      "packageNameTemplate": "pactfoundation/pact-broker",
-      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-pactbroker(?<compatibility>.*))?$"
+      "packageNameTemplate": "ghcr.io/pact-foundation/pact-broker",
+      "versioningTemplate": "loose"
     }
   ]
 }


### PR DESCRIPTION
- adds config for renovate to bump pact broker image
- moves to the ghcr image

Fixes https://github.com/pact-foundation/pact-broker-chart/issues/173