### PR TITLE
feat: Add image pull secret to dbclean job

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 6.2.0
+version: 6.2.1
 appVersion: 2.119.0
 dependencies:
   - name: common

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.119.0](https://img.shields.io/badge/AppVersion-2.119.0-informational?style=flat-square)
+![Version: 6.2.1](https://img.shields.io/badge/Version-6.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.119.0](https://img.shields.io/badge/AppVersion-2.119.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/ci/dbclean-with-image-pull-secret-values.yaml
+++ b/charts/pact-broker/ci/dbclean-with-image-pull-secret-values.yaml
@@ -1,0 +1,16 @@
+database:
+  host: "postgres.default.svc.cluster.local"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    password: "pactbroker-password"
+
+broker:
+  imagePullSecrets:
+    - my-registry-secret
+  config:
+    databaseClean:
+      enabled: true
+      mode: external

--- a/charts/pact-broker/templates/cronjob.yml
+++ b/charts/pact-broker/templates/cronjob.yml
@@ -16,6 +16,12 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.broker.imagePullSecrets }}
+          imagePullSecrets:
+          {{- range .Values.broker.imagePullSecrets }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           containers:
             - name: {{ template "chart.fullname" . }}-dbclean
               image: {{ template "broker.image" . }}


### PR DESCRIPTION
The db-clean cronjob did not include the imagePullSecret. We use a self hosted image cache which requires authentication. Since the cronjob reuses the broker image, it seems to make sense it should also reuse the imagePullSecret. 