### PR TITLE
feat: support multiple ingress hostnames via ingress.hosts

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 6.3.0
+version: 6.4.0
 appVersion: 2.120.0
 dependencies:
   - name: common

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.120.0](https://img.shields.io/badge/AppVersion-2.120.0-informational?style=flat-square)
+![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.120.0](https://img.shields.io/badge/AppVersion-2.120.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 
@@ -164,7 +164,8 @@ helm upgrade -i <release_name> oci://ghcr.io/pact-foundation/pact-broker-chart/p
 | ingress.annotations | ingress.annotations Additional annotations for the Ingress resource | object | `{}` |
 | ingress.className | ingress.className Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx) | string | `""` |
 | ingress.enabled | ingress.enabled Enable the creation of the ingress resource | bool | `true` |
-| ingress.host | host Hostname to be used to expose the route to access the Pact Broker | string | `""` |
+| ingress.host | host Hostname to be used to expose the route to access the Pact Broker. Ignored if `hosts` is non-empty. | string | `""` |
+| ingress.hosts | hosts List of hostnames to expose the route to access the Pact Broker on, all routed to the same backend. Takes precedence over `host` when non-empty; useful for exposing the broker under multiple hostnames (e.g. a stable alias alongside a cluster-specific hostname). | list | `[]` |
 | ingress.tls.enabled | ingress.tls.enabled Enable TLS configuration for the host defined at `ingress.host` parameter | bool | `false` |
 | ingress.tls.secretName | ingress.tls.secretName The name to which the TLS Secret will be called | string | `""` |
 | service.annotations | service.annotations Additional annotations for the Service resource | object | `{}` |

--- a/charts/pact-broker/ci/ingress-multiple-hosts-values.yaml
+++ b/charts/pact-broker/ci/ingress-multiple-hosts-values.yaml
@@ -1,0 +1,15 @@
+# CI test values for the Pact Broker deployment when exposing the Ingress
+# under multiple hostnames via ingress.hosts.
+database:
+  host: "postgres.default.svc.cluster.local"
+  port: "5432"
+  adapter: "postgres"
+  databaseName: "pactbroker"
+  auth:
+    username: "pactbroker"
+    password: "pactbroker-password"
+
+ingress:
+  hosts:
+    - pact-broker.example.com
+    - pact-broker-alias.example.com

--- a/charts/pact-broker/templates/ingress.yaml
+++ b/charts/pact-broker/templates/ingress.yaml
@@ -20,21 +20,29 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
+  {{- $hosts := .Values.ingress.hosts }}
+  {{- if not $hosts }}
+  {{- $hosts = list .Values.ingress.host }}
+  {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      - {{ .Values.ingress.host }}
+        {{- range $hosts }}
+        - {{ . }}
+        {{- end }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range $hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ include "common.names.fullname" . }}
+                name: {{ include "common.names.fullname" $ }}
                 port:
-                  number: {{ .Values.service.ports.http }}
+                  number: {{ $.Values.service.ports.http }}
+    {{- end }}
 {{- end }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -413,8 +413,14 @@ ingress:
   # -- ingress.annotations Additional annotations for the Ingress resource
   annotations: {}
 
-  # -- host Hostname to be used to expose the route to access the Pact Broker
+  # -- host Hostname to be used to expose the route to access the Pact Broker. Ignored if `hosts` is non-empty.
   host: ""
+
+  # -- hosts List of hostnames to expose the route to access the Pact Broker on, all
+  # routed to the same backend. Takes precedence over `host` when non-empty; useful for
+  # exposing the broker under multiple hostnames (e.g. a stable alias alongside a
+  # cluster-specific hostname).
+  hosts: []
 
   # Ingress TLS parameters
   tls:


### PR DESCRIPTION
## Description of the change

Adds optional `ingress.hosts` (list) to expose Pact Broker under multiple hostnames
from the same Ingress. Falls back to the existing `ingress.host` when unset — fully
backward compatible.

## Existing or Associated Issue(s)

None.

## Additional Information

Useful for a stable alias hostname alongside a cluster-specific one, e.g. during a
cluster migration.

## Checklist
- [x] Signed your commits
- [x] Chart version bumped in `Chart.yaml`
- [x] Chart version bumped in README badges
- [x] Variables documented in `values.yaml`, README regenerated via `helm-docs`
- [x] `ct lint` passes
