### PR TITLE
test: add Helm unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
           version: v3.16.4
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
 
       - name: Build chart dependencies
         run: helm dependency build charts/pact-broker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,17 @@ jobs:
       - name: Setup helm-docs
         run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1 # pin@v5.0.1
+        with:
+          version: v3.16.4
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/pact-broker
+
       - name: Run pre-commit
         uses: pre-commit/action@1b06ec171f2f6faa71ed760c4042bd969e4f8b43 # pin@v3.0.1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,11 @@ repos:
           - --template-files=./_templates.gotmpl
           # A base filename makes it relative to each chart directory found
           - --template-files=README.md.gotmpl
+  - repo: local
+    hooks:
+      - id: helm-unittest
+        name: helm-unittest
+        entry: helm unittest charts/pact-broker
+        language: system
+        files: ^charts/pact-broker/
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before making a contribution to the [Pact Broker Helm Chart](https://github.com/pact-foundation/pact-broker-chart) you will need to ensure the following steps have been done:
 - [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-- Install the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin with `helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2`, build the chart dependencies with `helm dependency build charts/pact-broker`, and run `helm unittest charts/pact-broker`.
+- Install the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin with `helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3`, build the chart dependencies with `helm dependency build charts/pact-broker`, and run `helm unittest charts/pact-broker`.
 - Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
 - List tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
 - Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run --all-files` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Before making a contribution to the [Pact Broker Helm Chart](https://github.com/pact-foundation/pact-broker-chart) you will need to ensure the following steps have been done:
 - [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+- Install the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin with `helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2`, build the chart dependencies with `helm dependency build charts/pact-broker`, and run `helm unittest charts/pact-broker`.
 - Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
 - List tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
 - Ensure variables are documented in `values.yaml` and the [pre-commit](https://pre-commit.com/) hook has been run with `pre-commit run --all-files` to generate the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: The Pact Broker is an application for sharing for Pact contracts and verification results.
 type: application
-version: 6.4.0
+version: 6.4.1
 appVersion: 2.120.0
 dependencies:
   - name: common

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -1,6 +1,6 @@
 # pact-broker
 
-![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.120.0](https://img.shields.io/badge/AppVersion-2.120.0-informational?style=flat-square)
+![Version: 6.4.1](https://img.shields.io/badge/Version-6.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.120.0](https://img.shields.io/badge/AppVersion-2.120.0-informational?style=flat-square)
 
 The Pact Broker is an application for sharing for Pact contracts and verification results.
 

--- a/charts/pact-broker/tests/cronjob_test.yaml
+++ b/charts/pact-broker/tests/cronjob_test.yaml
@@ -49,8 +49,26 @@ tests:
           value:
             - clean
       - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: ghcr.io/pact-foundation/pact-broker:2.142.0-pactbroker2.120.0
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
           path: spec.jobTemplate.spec.template.spec.restartPolicy
           value: Never
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_LOG_LEVEL
+            value: info
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PASSWORD
+            value: database-password
       - contains:
           path: spec.jobTemplate.spec.template.spec.containers[0].env
           content:
@@ -66,6 +84,11 @@ tests:
           content:
             name: PACT_BROKER_DATABASE_CLEAN_DRY_RUN
             value: "true"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_KEEP_VERSION_SELECTORS
+            value: '[{"latest": true}, { "max_age": 180 }]'
 
   - it: uses image pull secrets and an existing database secret
     set:
@@ -86,3 +109,41 @@ tests:
               secretKeyRef:
                 name: pact-broker-database
                 key: password
+
+  - it: applies image and logging overrides
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: external
+      broker.image: registry.example.com/pact-broker:legacy
+      broker.imagePullPolicy: Always
+      broker.config.logLevel: debug
+      broker.config.logFormat: json
+      broker.config.httpDebugLoggingEnabled: true
+      broker.config.hidePactflowMessages: false
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: registry.example.com/pact-broker:legacy
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_LOG_LEVEL
+            value: debug
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_LOG_FORMAT
+            value: json
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_HTTP_DEBUG_LOGGING_ENABLED
+            value: "true"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_HIDE_PACTFLOW_MESSAGES
+            value: "false"

--- a/charts/pact-broker/tests/cronjob_test.yaml
+++ b/charts/pact-broker/tests/cronjob_test.yaml
@@ -1,0 +1,88 @@
+suite: pact broker database cleanup cronjob
+templates:
+  - cronjob.yml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: does not render when database cleanup is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render for embedded database cleanup
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: embedded
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders external database cleanup settings
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: external
+      broker.config.databaseClean.cronSchedule: "0 2 * * *"
+      broker.config.databaseClean.deletionLimit: 250
+      broker.config.databaseClean.overwrittenDataMaxAge: 30
+      broker.config.databaseClean.dryRun: true
+      database.auth.password: database-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: pact-broker-dbclean
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: spec.schedule
+          value: "0 2 * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value:
+            - clean
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: Never
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_DELETION_LIMIT
+            value: "250"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_OVERWRITTEN_DATA_MAX_AGE
+            value: "30"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_DRY_RUN
+            value: "true"
+
+  - it: uses image pull secrets and an existing database secret
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: external
+      broker.imagePullSecrets[0]: registry-credentials
+      database.auth.existingSecret: pact-broker-database
+      database.auth.existingSecretPasswordKey: password
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[0].name
+          value: registry-credentials
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pact-broker-database
+                key: password

--- a/charts/pact-broker/tests/deployment_test.yaml
+++ b/charts/pact-broker/tests/deployment_test.yaml
@@ -49,6 +49,232 @@ tests:
             runAsUser: 1001
       - notExists:
           path: spec.template.spec.imagePullSecrets
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 2500m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 3
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+      - isEmpty:
+          path: spec.template.spec.containers[0].volumeMounts
+      - isEmpty:
+          path: spec.template.spec.volumes
+
+  - it: maps every configurable deployment and application setting
+    values:
+      - fixtures/deployment-all-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.annotations["example.com/restarted-at"]
+          value: "2026-09-05"
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.annotations["example.com/restarted-at"]
+          value: "2026-09-05"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: broker-runtime
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: false
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: https
+              containerPort: 8444
+              protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PACT_BROKER_LOG_LEVEL
+              value: debug
+            - name: PACT_BROKER_LOG_FORMAT
+              value: json
+            - name: PACT_BROKER_HTTP_DEBUG_LOGGING_ENABLED
+              value: "true"
+            - name: PACT_BROKER_HIDE_PACTFLOW_MESSAGES
+              value: "false"
+            - name: PACT_BROKER_DATABASE_ADAPTER
+              value: sqlite
+            - name: PACT_BROKER_DATABASE_HOST
+              value: postgres.example.com
+            - name: PACT_BROKER_DATABASE_PORT
+              value: "5433"
+            - name: PACT_BROKER_DATABASE_NAME
+              value: pact
+            - name: PACT_BROKER_DATABASE_USERNAME
+              value: broker
+            - name: PACT_BROKER_DATABASE_PASSWORD
+              value: database-password
+            - name: PACT_BROKER_DATABASE_SSLMODE
+              value: require
+            - name: PACT_BROKER_SQL_LOG_LEVEL
+              value: warn
+            - name: PACT_BROKER_SQL_LOG_WARN_DURATION
+              value: "9"
+            - name: PACT_BROKER_SQL_ENABLE_CALLER_LOGGING
+              value: "true"
+            - name: PACT_BROKER_DATABASE_MAX_CONNECTIONS
+              value: "20"
+            - name: PACT_BROKER_DATABASE_POOL_TIMEOUT
+              value: "10"
+            - name: PACT_BROKER_DATABASE_CONNECT_MAX_RETRIES
+              value: "8"
+            - name: PACT_BROKER_AUTO_MIGRATE_DB
+              value: "false"
+            - name: PACT_BROKER_AUTO_MIGRATE_DB_DATA
+              value: "false"
+            - name: PACT_BROKER_ALLOW_MISSING_MIGRATION_FILES
+              value: "false"
+            - name: PACT_BROKER_DATABASE_STATEMENT_TIMEOUT
+              value: "60"
+            - name: PACT_BROKER_METRICS_SQL_STATEMENT_TIMEOUT
+              value: "90"
+            - name: PACT_BROKER_DATABASE_CONNECTION_VALIDATION_TIMEOUT
+              value: "120"
+            - name: PACT_BROKER_DATABASE_CLEAN_ENABLED
+              value: "true"
+            - name: PACT_BROKER_DATABASE_CLEAN_CRON_SCHEDULE
+              value: "0 2 * * *"
+            - name: PACT_BROKER_DATABASE_CLEAN_DELETION_LIMIT
+              value: "250"
+            - name: PACT_BROKER_DATABASE_CLEAN_OVERWRITTEN_DATA_MAX_AGE
+              value: "30"
+            - name: PACT_BROKER_DATABASE_CLEAN_KEEP_VERSION_SELECTORS
+              value: '[{"latest": true}]'
+            - name: PACT_BROKER_DATABASE_CLEAN_DRY_RUN
+              value: "true"
+            - name: PACT_BROKER_BASIC_AUTH_ENABLED
+              value: "true"
+            - name: PACT_BROKER_BASIC_AUTH_USERNAME
+              value: writer
+            - name: PACT_BROKER_BASIC_AUTH_PASSWORD
+              value: write-password
+            - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
+              value: reader
+            - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
+              value: read-password
+            - name: PACT_BROKER_ALLOW_PUBLIC_READ
+              value: "true"
+            - name: PACT_BROKER_PUBLIC_HEARTBEAT
+              value: "false"
+            - name: PACT_BROKER_ENABLE_PUBLIC_BADGE_ACCESS
+              value: "true"
+            - name: PACT_BROKER_WEBHOOK_RETRY_SCHEDULE
+              value: 1 2 3
+            - name: PACT_BROKER_WEBHOOK_HTTP_METHOD_WHITELIST
+              value: POST PUT
+            - name: PACT_BROKER_WEBHOOK_HTTP_CODE_SUCCESS
+              value: 200 204
+            - name: PACT_BROKER_WEBHOOK_SCHEME_WHITELIST
+              value: https http
+            - name: PACT_BROKER_WEBHOOK_HOST_WHITELIST
+              value: example.com 10.0.0.0/8
+            - name: PACT_BROKER_DISABLE_SSL_VERIFICATION
+              value: "true"
+            - name: PACT_BROKER_PORT
+              value: "8080"
+            - name: PACT_BROKER_BASE_URL
+              value: https://broker.example.com
+            - name: PACT_BROKER_SHIELDS_IO_BASE_URL
+              value: https://shields.example.com
+            - name: PACT_BROKER_BADGE_PROVIDER_MODE
+              value: proxy
+            - name: PACT_BROKER_ENABLE_DIAGNOSTIC_ENDPOINTS
+              value: "false"
+            - name: PACT_BROKER_USE_HAL_BROWSER
+              value: "false"
+            - name: PACT_BROKER_CHECK_FOR_POTENTIAL_DUPLICATE_PACTICIPANT_NAMES
+              value: "false"
+            - name: PACT_BROKER_CREATE_DEPLOYED_VERSIONS_FOR_TAGS
+              value: "false"
+            - name: PACT_BROKER_USE_FIRST_TAG_AS_BRANCH
+              value: "false"
+            - name: PACT_BROKER_AUTO_DETECT_MAIN_BRANCH
+              value: "false"
+            - name: PACT_BROKER_MAIN_BRANCH_CANDIDATES
+              value: trunk main
+            - name: PACT_BROKER_ALLOW_DANGEROUS_CONTRACT_MODIFICATION
+              value: "true"
+            - name: PACT_BROKER_PACT_CONTENT_DIFF_TIMEOUT
+              value: "60"
+            - name: PACT_BROKER_FEATURES
+              value: feature-a feature-b
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 4
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 5
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 2
 
   - it: supports image, replica, pull secret, and security context overrides
     set:
@@ -79,6 +305,31 @@ tests:
           path: spec.template.spec.securityContext
       - notExists:
           path: spec.template.spec.containers[0].securityContext
+
+  - it: supports the legacy string image setting
+    set:
+      broker.image: registry.example.com/pact-broker:legacy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/pact-broker:legacy
+
+  - it: selects the correct service account when creation is disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+
+  - it: selects a named existing service account
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: existing-runtime
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-runtime
 
   - it: uses a directly configured database password
     set:
@@ -118,6 +369,49 @@ tests:
               secretKeyRef:
                 name: pact-broker-database
                 key: password
+
+  - it: gives direct database and auth credentials precedence over secrets
+    set:
+      database.auth.password: direct-database-password
+      database.auth.existingSecret: ignored-database-secret
+      database.auth.existingSecretPasswordKey: ignored-password
+      broker.config.basicAuth.enabled: true
+      broker.config.basicAuth.writeUser.username: direct-writer
+      broker.config.basicAuth.writeUser.password: direct-write-password
+      broker.config.basicAuth.writeUser.existingSecret: ignored-write-secret
+      broker.config.basicAuth.writeUser.existingSecretUsernameKey: username
+      broker.config.basicAuth.writeUser.existingSecretPasswordKey: password
+      broker.config.basicAuth.readUser.username: direct-reader
+      broker.config.basicAuth.readUser.password: direct-read-password
+      broker.config.basicAuth.readUser.existingSecret: ignored-read-secret
+      broker.config.basicAuth.readUser.existingSecretUsernameKey: username
+      broker.config.basicAuth.readUser.existingSecretPasswordKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PASSWORD
+            value: direct-database-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_USERNAME
+            value: direct-writer
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_PASSWORD
+            value: direct-write-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
+            value: direct-reader
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
+            value: direct-read-password
 
   - it: adds embedded database cleanup settings only when enabled
     set:
@@ -235,6 +529,35 @@ tests:
           content:
             name: PACT_BROKER_FEATURES
             value: feature-a
+
+  - it: omits optional and embedded-cleanup environment variables by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_WEBHOOK_HOST_WHITELIST
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASE_URL
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_FEATURES
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_ENABLED
+
+  - it: leaves embedded-cleanup variables out in external mode
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: external
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_ENABLED
 
   - it: supports scheduling, storage, sidecars, and disabled probes
     values:

--- a/charts/pact-broker/tests/deployment_test.yaml
+++ b/charts/pact-broker/tests/deployment_test.yaml
@@ -1,0 +1,269 @@
+suite: pact broker deployment
+templates:
+  - deployment.yaml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: renders the deployment defaults
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: pact-broker
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 10
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: pact-broker
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/pact-foundation/pact-broker:2.142.0-pactbroker2.120.0
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: http
+            containerPort: 9292
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].ports[1]
+          value:
+            name: https
+            containerPort: 8443
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsNonRoot: true
+            runAsUser: 1001
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: supports image, replica, pull secret, and security context overrides
+    set:
+      broker.image.repository: registry.example.com/pact-broker
+      broker.image.tag: test
+      broker.imagePullPolicy: Always
+      broker.imagePullSecrets[0]: registry-credentials
+      broker.replicaCount: 3
+      broker.revisionHistoryLimit: 0
+      broker.podSecurityContext.enabled: false
+      broker.containerSecurityContext.enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - notExists:
+          path: spec.revisionHistoryLimit
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: registry-credentials
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/pact-broker:test
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - notExists:
+          path: spec.template.spec.securityContext
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: uses a directly configured database password
+    set:
+      database.host: postgres.example.com
+      database.port: "5433"
+      database.adapter: postgres
+      database.databaseName: pact
+      database.auth.username: broker
+      database.auth.password: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_HOST
+            value: postgres.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PORT
+            value: "5433"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PASSWORD
+            value: password
+
+  - it: reads the database password from an existing secret
+    set:
+      database.auth.existingSecret: pact-broker-database
+      database.auth.existingSecretPasswordKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pact-broker-database
+                key: password
+
+  - it: adds embedded database cleanup settings only when enabled
+    set:
+      broker.config.databaseClean.enabled: true
+      broker.config.databaseClean.mode: embedded
+      broker.config.databaseClean.cronSchedule: "0 2 * * *"
+      broker.config.databaseClean.dryRun: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_CRON_SCHEDULE
+            value: "0 2 * * *"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_DATABASE_CLEAN_DRY_RUN
+            value: "true"
+
+  - it: configures basic auth with direct credentials
+    set:
+      broker.config.basicAuth.enabled: true
+      broker.config.basicAuth.writeUser.username: writer
+      broker.config.basicAuth.writeUser.password: write-password
+      broker.config.basicAuth.readUser.username: reader
+      broker.config.basicAuth.readUser.password: read-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_USERNAME
+            value: writer
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_PASSWORD
+            value: write-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
+            value: reader
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
+            value: read-password
+
+  - it: configures basic auth with existing secrets
+    set:
+      broker.config.basicAuth.enabled: true
+      broker.config.basicAuth.writeUser.existingSecret: write-credentials
+      broker.config.basicAuth.writeUser.existingSecretUsernameKey: username
+      broker.config.basicAuth.writeUser.existingSecretPasswordKey: password
+      broker.config.basicAuth.readUser.existingSecret: read-credentials
+      broker.config.basicAuth.readUser.existingSecretUsernameKey: username
+      broker.config.basicAuth.readUser.existingSecretPasswordKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: write-credentials
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: write-credentials
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: read-credentials
+                key: username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: read-credentials
+                key: password
+
+  - it: controls optional environment variables
+    set:
+      broker.config.webhookHostWhitelist: example.com
+      broker.config.baseUrl: https://broker.example.com
+      broker.config.features: feature-a
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_WEBHOOK_HOST_WHITELIST
+            value: example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_BASE_URL
+            value: https://broker.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PACT_BROKER_FEATURES
+            value: feature-a
+
+  - it: supports scheduling, storage, sidecars, and disabled probes
+    values:
+      - fixtures/deployment-overrides-values.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.template.spec.tolerations[0]
+          value:
+            key: dedicated
+            operator: Exists
+      - exists:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: cache
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            mountPath: /cache
+            name: cache
+      - equal:
+          path: spec.template.spec.containers[1]
+          value:
+            image: busybox:1.36
+            name: sidecar

--- a/charts/pact-broker/tests/fixtures/deployment-all-values.yaml
+++ b/charts/pact-broker/tests/fixtures/deployment-all-values.yaml
@@ -1,0 +1,107 @@
+broker:
+  labels:
+    team: platform
+  annotations:
+    example.com/restarted-at: "2026-09-05"
+  containerPorts:
+    http: 8080
+    https: 8444
+  podSecurityContext:
+    enabled: true
+    fsGroup: 2000
+    fsGroupChangePolicy: OnRootMismatch
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 2000
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+  config:
+    logLevel: debug
+    logFormat: json
+    httpDebugLoggingEnabled: true
+    hidePactflowMessages: false
+    databaseSslmode: require
+    sqlLogLevel: warn
+    sqlLogWarnDuration: 9
+    sqlEnableCallerLogging: true
+    databaseMaxConnections: 20
+    databasePoolTimeout: 10
+    databaseConnectMaxRetries: 8
+    autoMigrateDb: false
+    autoMigrateDbData: false
+    allowMissingMigrationFiles: false
+    databaseStatementTimeout: 60
+    metricsSqlStatementTimeout: 90
+    databaseConnectionValidationTimeout: 120
+    basicAuth:
+      enabled: true
+      allowPublicRead: true
+      publicHeartbeat: false
+      enablePublicBadgeAccess: true
+      writeUser:
+        username: writer
+        password: write-password
+      readUser:
+        username: reader
+        password: read-password
+    webhookRetrySchedule: 1 2 3
+    webhookHttpMethodWhitelist: POST PUT
+    webhookHttpCodeSuccess: 200 204
+    webhookSchemeWhitelist: https http
+    webhookHostWhitelist: example.com 10.0.0.0/8
+    disable_ssl: true
+    baseUrl: https://broker.example.com
+    shieldsIoBaseUrl: https://shields.example.com
+    badgeProviderMode: proxy
+    enableDiagnosticEndpoints: false
+    useHalBrowser: false
+    checkForPotentialDuplicatePacticipantNames: false
+    createDeployedVersionsForTags: false
+    useFirstTagAsBranch: false
+    autoDetectMainBranch: false
+    mainBranchCandidates: trunk main
+    allowDangerousContractModification: true
+    pactContentDiffTimeout: 60
+    features: feature-a feature-b
+    databaseClean:
+      enabled: true
+      mode: embedded
+      cronSchedule: 0 2 * * *
+      deletionLimit: 250
+      overwrittenDataMaxAge: 30
+      keepVersionSelectors: '[{"latest": true}]'
+      dryRun: true
+  resources:
+    limits:
+      cpu: "1"
+      memory: 2Gi
+    requests:
+      cpu: 250m
+      memory: 1Gi
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 4
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    timeoutSeconds: 2
+    failureThreshold: 5
+    successThreshold: 1
+
+database:
+  host: postgres.example.com
+  port: "5433"
+  adapter: sqlite
+  databaseName: pact
+  auth:
+    username: broker
+    password: database-password
+
+serviceAccount:
+  name: broker-runtime
+  automountServiceAccountToken: false

--- a/charts/pact-broker/tests/fixtures/deployment-overrides-values.yaml
+++ b/charts/pact-broker/tests/fixtures/deployment-overrides-values.yaml
@@ -1,0 +1,26 @@
+broker:
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    enabled: false
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - key: dedicated
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: zone
+                operator: Exists
+  volumes:
+    - name: cache
+      emptyDir: {}
+  volumeMounts:
+    - name: cache
+      mountPath: /cache
+  extraContainers:
+    - name: sidecar
+      image: busybox:1.36

--- a/charts/pact-broker/tests/fixtures/ingress-multiple-hosts-values.yaml
+++ b/charts/pact-broker/tests/fixtures/ingress-multiple-hosts-values.yaml
@@ -1,0 +1,8 @@
+ingress:
+  host: ignored.example.com
+  hosts:
+    - broker.example.com
+    - broker-alias.example.com
+  tls:
+    enabled: true
+    secretName: broker-tls

--- a/charts/pact-broker/tests/fixtures/metadata-values.yaml
+++ b/charts/pact-broker/tests/fixtures/metadata-values.yaml
@@ -1,0 +1,18 @@
+commonLabels:
+  company: pact
+commonAnnotations:
+  common.example.com/release: '{{ .Release.Name }}'
+
+broker:
+  labels:
+    team: platform
+  annotations:
+    deployment.example.com/release: pact-broker
+
+service:
+  annotations:
+    service.example.com/release: '{{ .Release.Name }}'
+
+ingress:
+  annotations:
+    ingress.example.com/release: '{{ .Release.Name }}'

--- a/charts/pact-broker/tests/fixtures/service-account-pull-secrets-values.yaml
+++ b/charts/pact-broker/tests/fixtures/service-account-pull-secrets-values.yaml
@@ -1,0 +1,4 @@
+serviceAccount:
+  imagePullSecrets:
+    - first-registry
+    - second-registry

--- a/charts/pact-broker/tests/fixtures/service-legacy-ports-values.yaml
+++ b/charts/pact-broker/tests/fixtures/service-legacy-ports-values.yaml
@@ -1,0 +1,6 @@
+service:
+  ports:
+    http: null
+    https: null
+  port: 8080
+  httpsPort: 8443

--- a/charts/pact-broker/tests/ingress_test.yaml
+++ b/charts/pact-broker/tests/ingress_test.yaml
@@ -1,0 +1,75 @@
+suite: pact broker ingress
+templates:
+  - ingress.yaml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: renders the default ingress
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: pact-broker
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service
+          value:
+            name: pact-broker
+            port:
+              number: 80
+      - notExists:
+          path: spec.tls
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: does not render when ingress is disabled
+    set:
+      ingress.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: configures a single host, class, and TLS
+    set:
+      ingress.host: broker.example.com
+      ingress.className: nginx
+      ingress.tls.enabled: true
+      ingress.tls.secretName: broker-tls
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: broker.example.com
+      - equal:
+          path: spec.tls[0]
+          value:
+            hosts:
+              - broker.example.com
+            secretName: broker-tls
+
+  - it: gives multiple hosts precedence over the legacy host
+    values:
+      - fixtures/ingress-multiple-hosts-values.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+      - equal:
+          path: spec.rules[0].host
+          value: broker.example.com
+      - equal:
+          path: spec.rules[1].host
+          value: broker-alias.example.com
+      - equal:
+          path: spec.tls[0].hosts
+          value:
+            - broker.example.com
+            - broker-alias.example.com

--- a/charts/pact-broker/tests/ingress_test.yaml
+++ b/charts/pact-broker/tests/ingress_test.yaml
@@ -23,10 +23,18 @@ tests:
             name: pact-broker
             port:
               number: 80
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
       - notExists:
           path: spec.tls
       - notExists:
           path: spec.ingressClassName
+      - isEmpty:
+          path: metadata.annotations
 
   - it: does not render when ingress is disabled
     set:
@@ -55,6 +63,32 @@ tests:
               - broker.example.com
             secretName: broker-tls
 
+  - it: propagates common labels and rendered annotations
+    values:
+      - fixtures/metadata-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: pact-broker
+      - equal:
+          path: metadata.labels.company
+          value: pact
+      - equal:
+          path: metadata.annotations["ingress.example.com/release"]
+          value: pact-broker
+      - equal:
+          path: metadata.annotations["common.example.com/release"]
+          value: pact-broker
+
+  - it: routes to a customized HTTP service port
+    set:
+      ingress.host: broker.example.com
+      service.ports.http: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+
   - it: gives multiple hosts precedence over the legacy host
     values:
       - fixtures/ingress-multiple-hosts-values.yaml
@@ -68,6 +102,9 @@ tests:
       - equal:
           path: spec.rules[1].host
           value: broker-alias.example.com
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: pact-broker
       - equal:
           path: spec.tls[0].hosts
           value:

--- a/charts/pact-broker/tests/naming_test.yaml
+++ b/charts/pact-broker/tests/naming_test.yaml
@@ -1,0 +1,55 @@
+suite: pact broker naming helpers
+templates:
+  - service.yaml
+release:
+  name: example
+  namespace: pact-broker-system
+tests:
+  - it: combines a release name that does not contain the chart name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: example-pact-broker
+      - equal:
+          path: metadata.labels.name
+          value: example-pact-broker
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: pact-broker
+
+  - it: applies nameOverride to resource names and application labels
+    set:
+      nameOverride: contract-broker
+    asserts:
+      - equal:
+          path: metadata.name
+          value: example-contract-broker
+      - equal:
+          path: metadata.labels.name
+          value: example-contract-broker
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: contract-broker
+
+  - it: gives fullnameOverride precedence over generated resource names
+    set:
+      nameOverride: contract-broker
+      fullnameOverride: custom-broker
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-broker
+      - equal:
+          path: metadata.labels.name
+          value: custom-broker
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: contract-broker
+
+  - it: truncates a long fullnameOverride to a valid Kubernetes name
+    set:
+      fullnameOverride: this-is-a-very-long-pact-broker-resource-name-that-exceeds-sixty-three-characters
+    asserts:
+      - equal:
+          path: metadata.name
+          value: this-is-a-very-long-pact-broker-resource-name-that-exceeds-sixt

--- a/charts/pact-broker/tests/poddisruptionbudget_test.yaml
+++ b/charts/pact-broker/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,49 @@
+suite: pact broker pod disruption budget
+templates:
+  - poddisruptionbudget.yaml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: does not render for a single replica
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders maxUnavailable for multiple replicas
+    set:
+      broker.replicaCount: 3
+      broker.podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: pact-broker
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/instance: pact-broker
+            app.kubernetes.io/name: pact-broker
+
+  - it: supports minAvailable instead of maxUnavailable
+    set:
+      broker.replicaCount: 2
+      broker.podDisruptionBudget.maxUnavailable: null
+      broker.podDisruptionBudget.minAvailable: 1
+    asserts:
+      - notExists:
+          path: spec.maxUnavailable
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/charts/pact-broker/tests/poddisruptionbudget_test.yaml
+++ b/charts/pact-broker/tests/poddisruptionbudget_test.yaml
@@ -10,6 +10,13 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: does not render for zero replicas
+    set:
+      broker.replicaCount: 0
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders maxUnavailable for multiple replicas
     set:
       broker.replicaCount: 3
@@ -47,3 +54,37 @@ tests:
       - equal:
           path: spec.minAvailable
           value: 1
+
+  - it: supports percentage availability values
+    set:
+      broker.replicaCount: 3
+      broker.podDisruptionBudget.maxUnavailable: null
+      broker.podDisruptionBudget.minAvailable: 50%
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 50%
+
+  - it: renders both constraints when both are configured
+    set:
+      broker.replicaCount: 3
+      broker.podDisruptionBudget.maxUnavailable: 1
+      broker.podDisruptionBudget.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: omits zero-valued constraints
+    set:
+      broker.replicaCount: 2
+      broker.podDisruptionBudget.maxUnavailable: 0
+      broker.podDisruptionBudget.minAvailable: 0
+    asserts:
+      - notExists:
+          path: spec.maxUnavailable
+      - notExists:
+          path: spec.minAvailable

--- a/charts/pact-broker/tests/service_test.yaml
+++ b/charts/pact-broker/tests/service_test.yaml
@@ -1,0 +1,78 @@
+suite: pact broker service
+templates:
+  - service.yaml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: renders the ClusterIP service defaults
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: pact-broker
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0]
+          value:
+            name: http
+            nodePort: null
+            port: 80
+            protocol: TCP
+            targetPort: http
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: https
+            nodePort: null
+            port: 443
+            protocol: TCP
+            targetPort: https
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: pact-broker
+            app.kubernetes.io/name: pact-broker
+
+  - it: configures a fixed cluster IP
+    set:
+      service.clusterIP: 10.0.0.42
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: 10.0.0.42
+
+  - it: configures load balancer IP and node ports
+    set:
+      service.type: LoadBalancer
+      service.loadBalancerIP: 203.0.113.10
+      service.nodePorts.http: 30080
+      service.nodePorts.https: 30443
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerIP
+          value: 203.0.113.10
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30080
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30443
+
+  - it: omits node ports when they are not explicitly configured
+    set:
+      service.type: NodePort
+    asserts:
+      - notExists:
+          path: spec.ports[0].nodePort
+      - notExists:
+          path: spec.ports[1].nodePort

--- a/charts/pact-broker/tests/service_test.yaml
+++ b/charts/pact-broker/tests/service_test.yaml
@@ -39,6 +39,26 @@ tests:
           value:
             app.kubernetes.io/instance: pact-broker
             app.kubernetes.io/name: pact-broker
+      - isEmpty:
+          path: metadata.annotations
+      - notExists:
+          path: spec.clusterIP
+      - notExists:
+          path: spec.loadBalancerIP
+
+  - it: propagates common labels and rendered annotations
+    values:
+      - fixtures/metadata-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.company
+          value: pact
+      - equal:
+          path: metadata.annotations["service.example.com/release"]
+          value: pact-broker
+      - equal:
+          path: metadata.annotations["common.example.com/release"]
+          value: pact-broker
 
   - it: configures a fixed cluster IP
     set:
@@ -68,6 +88,19 @@ tests:
           path: spec.ports[1].nodePort
           value: 30443
 
+  - it: configures explicit node ports on a NodePort service
+    set:
+      service.type: NodePort
+      service.nodePorts.http: 30080
+      service.nodePorts.https: 30443
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30080
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30443
+
   - it: omits node ports when they are not explicitly configured
     set:
       service.type: NodePort
@@ -76,3 +109,39 @@ tests:
           path: spec.ports[0].nodePort
       - notExists:
           path: spec.ports[1].nodePort
+
+  - it: ignores cluster and load balancer IPs for incompatible service types
+    set:
+      service.type: NodePort
+      service.clusterIP: 10.0.0.42
+      service.loadBalancerIP: 203.0.113.10
+    asserts:
+      - notExists:
+          path: spec.clusterIP
+      - notExists:
+          path: spec.loadBalancerIP
+
+  - it: uses legacy ports when the modern ports are empty
+    values:
+      - fixtures/service-legacy-ports-values.yaml
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[1].port
+          value: 8443
+
+  - it: gives modern ports precedence over legacy ports
+    set:
+      service.ports.http: 8080
+      service.ports.https: 8443
+      service.port: 9080
+      service.httpsPort: 9443
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[1].port
+          value: 8443

--- a/charts/pact-broker/tests/serviceaccount_test.yaml
+++ b/charts/pact-broker/tests/serviceaccount_test.yaml
@@ -1,0 +1,55 @@
+suite: pact broker service account
+templates:
+  - serviceaccount.yaml
+release:
+  name: pact-broker
+  namespace: pact-broker-system
+tests:
+  - it: renders the default service account
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: pact-broker
+      - equal:
+          path: metadata.namespace
+          value: pact-broker-system
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+      - notExists:
+          path: imagePullSecrets
+
+  - it: does not render when service account creation is disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: configures a custom name, token setting, metadata, and pull secret
+    set:
+      serviceAccount.name: broker-runtime
+      serviceAccount.automountServiceAccountToken: false
+      serviceAccount.labels.team: platform
+      serviceAccount.annotations.example: test
+      serviceAccount.imagePullSecrets[0]: registry-credentials
+    asserts:
+      - equal:
+          path: metadata.name
+          value: broker-runtime
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.annotations.example
+          value: test
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+      - equal:
+          path: imagePullSecrets[0].name
+          value: registry-credentials

--- a/charts/pact-broker/tests/serviceaccount_test.yaml
+++ b/charts/pact-broker/tests/serviceaccount_test.yaml
@@ -53,3 +53,13 @@ tests:
       - equal:
           path: imagePullSecrets[0].name
           value: registry-credentials
+
+  - it: attaches every configured image pull secret
+    values:
+      - fixtures/service-account-pull-secrets-values.yaml
+    asserts:
+      - equal:
+          path: imagePullSecrets
+          value:
+            - name: first-registry
+            - name: second-registry


### PR DESCRIPTION
## Description of the change

- Add semantic `helm-unittest` suites for every Pact Broker chart resource and helper.
- Cover every independently configurable rendering branch, including defaults, metadata, naming overrides, image formats, database credentials, basic auth, cleanup modes, ingress hosts and TLS, service types and ports, service accounts, disruption budgets, scheduling, storage, security contexts, resources, and probes.
- Assert every Pact Broker application setting is mapped to the expected environment variable.
- Run the tests through pre-commit and CI, with chart dependencies built before execution.
- Document local setup and bump the chart patch version to 6.4.1.

## Existing or Associated Issue(s)

Closes #271.

## Additional Information

The test layout and pre-commit integration follow the approach used by the Backstage charts repository.

Validation completed locally:

- `pre-commit run --all-files`
- `helm unittest charts/pact-broker` (51 tests across 7 suites)
- `helm lint charts/pact-broker`
- `ct lint --config ct.yaml --all`

## Checklist

- [x] Signed the commits.
- [x] Bumped the chart version in `Chart.yaml`.
- [x] Regenerated the README badge.
- [x] Ran pre-commit across all files.
- [x] Ran chart-testing lint successfully.